### PR TITLE
Docs: Clarify mention command behavior in README and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ A simple Discord bot built with discord.py.
 
 ## Features
 
-- Processes `/bot <query>` commands and responds with AI-generated answers using OpenRouter API
+- Processes queries via mentions (`@botname <query>`) and responds with AI-generated answers using OpenRouter API
 - Summarizes channel conversations with `/sum-day` command to get a summary of the day's messages
 - Automatically generates daily summaries for all active channels at a scheduled time
 - Stores summaries in a dedicated database table and optionally posts them to a reports channel
 - Automatically cleans up old message records after summarization to manage database size
 - Automatically splits long messages into multiple parts to handle Discord's 2000 character limit
 - Rate limiting to prevent abuse (10 seconds between requests, max 6 requests per minute)
-- `/bot` command only responds in the #bot-talk channel
+- Mention-based queries (e.g., `@botname <query>`) allow you to interact with the bot in any channel. While originally envisaged for a dedicated `#bot-talk` channel, the current implementation allows use in all channels.
 - `/sum-day` command works in any channel
 - Stores all messages in a SQLite database for logging and analysis
 
@@ -71,7 +71,7 @@ To use the message content intent, you need to enable it in the Discord Develope
 
 ### Basic Commands
 
-- `/bot <query>`: Sends your query to an AI model via OpenRouter and returns the response
+- `@botname <query>`: Sends your query to an AI model via OpenRouter and returns the response. This command works in any channel.
 
 ### Channel Summarization
 
@@ -183,7 +183,7 @@ If you encounter database-related errors:
 
 ### 2023-05-25
 - Modified the `/sum-day` command to work in any channel (not just #bot-talk)
-- Kept the `/bot` command restricted to the #bot-talk channel
+- Mention-based queries (`@botname <query>`) are available in all channels.
 - Updated documentation to reflect these changes
 
 ### 2023-05-20
@@ -191,7 +191,7 @@ If you encounter database-related errors:
 - Simplified command handling in the bot
 
 ### 2023-05-15
-- Fixed issue where bot responses to `/bot` commands were not being stored in the database
+- Fixed issue where bot responses to mention-based queries (`@botname <query>`) were not being stored in the database
 - Now storing all bot responses in the database, including error messages and rate limit notifications
 - Modified `/sum-day` command to include bot responses in the summary
 - Improved error handling and logging for database operations

--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,7 @@ async def on_ready():
         # Check if bot-talk channel exists
         bot_talk_exists = any(channel.name == 'bot-talk' for channel in guild.text_channels)
         if not bot_talk_exists:
-            logger.warning(f'Guild {guild.name} does not have a #bot-talk channel. The /bot command will not work in this guild, but /sum-day will still function in all channels.')
+            logger.warning(f'Guild {guild.name} does not have a #bot-talk channel. While the bot\'s mention-based query functionality (e.g., @botname <query>) currently works in all channels, a #bot-talk channel was originally intended as a dedicated space for these interactions. The /sum-day command will still function in all channels.')
 
 @client.event
 async def on_guild_join(guild):
@@ -61,7 +61,7 @@ async def on_guild_join(guild):
     # Check if bot-talk channel exists
     bot_talk_exists = any(channel.name == 'bot-talk' for channel in guild.text_channels)
     if not bot_talk_exists:
-        logger.warning(f'Guild {guild.name} does not have a #bot-talk channel. The /bot command will not work in this guild, but /sum-day will still function in all channels.')
+        logger.warning(f'Guild {guild.name} does not have a #bot-talk channel. While the bot\'s mention-based query functionality (e.g., @botname <query>) currently works in all channels, a #bot-talk channel was originally intended as a dedicated space for these interactions. The /sum-day command will still function in all channels.')
 
 @client.event
 async def on_guild_remove(guild):


### PR DESCRIPTION
I've updated README.md and internal log messages in bot.py to accurately reflect that mention-based commands (@botname <query>) currently operate in any channel.

Previously, the documentation and logs suggested these commands were, or should be, restricted to a #bot-talk channel. This commit aligns the documentation with the actual implemented behavior. No functional code changes were made to command processing logic based on your feedback to keep existing functionality.

Changes include:
- README.md: Text updated to state mention queries work in all channels, while noting the original design intention for a #bot-talk channel.
- bot.py: Warning logs in on_ready and on_guild_join updated to reflect that mention queries work in all channels, clarifying the role of a #bot-talk channel as an intended dedicated space rather than a current restriction.