### PR TITLE
feat: Add slash commands for summaries

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,22 +24,25 @@ intents.message_content = True  # This is required to read message content in gu
 
 client = commands.Bot(command_prefix='!', intents=intents)
 
+class MockMessage:
+    """Mock message object for compatibility with existing command handlers"""
+    def __init__(self, interaction, command="sum-day", hours=None):
+        self.author = interaction.user
+        self.channel = interaction.channel
+        self.guild = interaction.guild
+        if command == "sum-hr" and hours is not None:
+            self.content = f"/sum-hr {hours}"
+        else:
+            self.content = "/sum-day"
+        
+    async def create_thread(self, name):
+        return await self.channel.create_thread(name=name)
+
 # Slash command definitions
 @client.tree.command(name="sum-day", description="Generate a summary of the past 24 hours in this channel")
 async def sum_day_slash(interaction: discord.Interaction):
     """Slash command for daily channel summary"""
     await interaction.response.defer()
-    
-    # Create a mock message object for compatibility with existing handler
-    class MockMessage:
-        def __init__(self, interaction):
-            self.author = interaction.user
-            self.channel = interaction.channel
-            self.guild = interaction.guild
-            self.content = "/sum-day"
-            
-        async def create_thread(self, name):
-            return await self.channel.create_thread(name=name)
     
     mock_message = MockMessage(interaction)
     
@@ -72,18 +75,7 @@ async def sum_hr_slash(interaction: discord.Interaction, hours: int):
         await interaction.followup.send("❌ Number of hours cannot exceed 168 (7 days).", ephemeral=True)
         return
     
-    # Create a mock message object for compatibility with existing handler
-    class MockMessage:
-        def __init__(self, interaction, hours):
-            self.author = interaction.user
-            self.channel = interaction.channel
-            self.guild = interaction.guild
-            self.content = f"/sum-hr {hours}"
-            
-        async def create_thread(self, name):
-            return await self.channel.create_thread(name=name)
-    
-    mock_message = MockMessage(interaction, hours)
+    mock_message = MockMessage(interaction, command="sum-hr", hours=hours)
     
     # Use existing handler logic
     try:

--- a/bot.py
+++ b/bot.py
@@ -52,14 +52,14 @@ async def sum_day_slash(interaction: discord.Interaction):
         # If no exception, the command succeeded
         try:
             await interaction.followup.send("✅ Daily summary has been generated!", ephemeral=True)
-        except:
-            pass  # Ignore if we can't send the followup
+        except discord.HTTPException as e:
+            logger.warning(f"Failed to send followup message: {e}")
     except Exception as e:
         logger.error(f"Error in sum-day slash command: {e}")
         try:
             await interaction.followup.send("❌ An error occurred while generating the summary.", ephemeral=True)
-        except:
-            pass
+        except discord.HTTPException as e:
+            logger.warning(f"Failed to send error followup message: {e}")
 
 @client.tree.command(name="sum-hr", description="Generate a summary of the past N hours in this channel")
 async def sum_hr_slash(interaction: discord.Interaction, hours: int):
@@ -83,14 +83,14 @@ async def sum_hr_slash(interaction: discord.Interaction, hours: int):
         # If no exception, the command succeeded
         try:
             await interaction.followup.send(f"✅ {hours}-hour summary has been generated!", ephemeral=True)
-        except:
-            pass  # Ignore if we can't send the followup
+        except discord.HTTPException as e:
+            logger.warning(f"Failed to send followup message: {e}")
     except Exception as e:
         logger.error(f"Error in sum-hr slash command: {e}")
         try:
             await interaction.followup.send("❌ An error occurred while generating the summary.", ephemeral=True)
-        except:
-            pass
+        except discord.HTTPException as e:
+            logger.warning(f"Failed to send error followup message: {e}")
 
 async def process_url(message_id: str, url: str):
     """


### PR DESCRIPTION
This PR adds Discord slash command support for:

- /sum-day: Generate a summary of the past 24 hours in a channel
- /sum-hr: Generate a summary of the past N hours in a channel

Changes include:
- Migrated from discord.Client to commands.Bot for slash command support
- Added command implementations with proper error handling
- Added command syncing on bot startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new slash commands `/sum-day` and `/sum-hr` for easier interaction within Discord.
	- `/sum-hr` now validates the hours parameter to ensure it is a positive integer up to 168.
- **Improvements**
	- Enhanced command synchronization with Discord, providing feedback on the number of available slash commands.
	- Improved error handling and user feedback for slash command usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->