### PR TITLE
Add GitHub Actions automated testing setup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [tool:pytest]
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
+asyncio_default_test_loop_scope = function
+asyncio_fixture_loop_scope = function
 testpaths = .
 python_files = test_*.py
 python_classes = Test*

--- a/test_database.py
+++ b/test_database.py
@@ -25,10 +25,9 @@ def test_database_init():
     try:
         database.init_database()
         logger.info("Database initialized successfully")
-        return True
     except Exception as e:
         logger.error(f"Database initialization failed: {str(e)}", exc_info=True)
-        return False
+        assert False, f"Database initialization failed: {str(e)}"
 
 def test_message_storage():
     """Test message storage functionality"""
@@ -65,7 +64,7 @@ def test_message_storage():
             logger.info(f"Message {message_id} stored successfully")
         else:
             logger.error(f"Failed to store message {message_id}")
-            return False
+            assert False, f"Failed to store message {message_id}"
 
         # Get message count
         count = database.get_message_count()
@@ -75,10 +74,9 @@ def test_message_storage():
         user_count = database.get_user_message_count(author_id)
         logger.info(f"User message count for {author_id}: {user_count}")
 
-        return True
     except Exception as e:
         logger.error(f"Message storage test failed: {str(e)}", exc_info=True)
-        return False
+        assert False, f"Message storage test failed: {str(e)}"
 
 def main():
     """Run all tests"""

--- a/test_message_links_simple.py
+++ b/test_message_links_simple.py
@@ -17,52 +17,48 @@ from logging_config import logger
 def test_message_links():
     """Test that message link generation works correctly."""
     logger.info("Starting test for message link generation...")
-    
+
     # Initialize database
     init_database()
-    
+
     # Test data
     guild_id = "123456789012345678"
     channel_id = "987654321098765432"
     channel_name = "test-channel"
     today = datetime.now(timezone.utc)
-    
+
     # Test message link generation
     test_message_id = "msg123"
     test_link = generate_discord_message_link(guild_id, channel_id, test_message_id)
     expected_link = f"https://discord.com/channels/{guild_id}/{channel_id}/{test_message_id}"
-    
+
     logger.info(f"Generated link: {test_link}")
     logger.info(f"Expected link: {expected_link}")
-    
-    if test_link == expected_link:
-        logger.info("✓ Message link generation works correctly!")
-    else:
-        logger.error("✗ Message link generation failed!")
-        return False
-    
+
+    assert test_link == expected_link, f"Message link generation failed! Expected: {expected_link}, Got: {test_link}"
+    logger.info("✓ Message link generation works correctly!")
+
     # Test DM link generation (no guild_id)
     dm_link = generate_discord_message_link(None, channel_id, test_message_id)
     expected_dm_link = f"https://discord.com/channels/@me/{channel_id}/{test_message_id}"
-    
+
     logger.info(f"Generated DM link: {dm_link}")
     logger.info(f"Expected DM link: {expected_dm_link}")
-    
-    if dm_link == expected_dm_link:
-        logger.info("✓ DM message link generation works correctly!")
-    else:
-        logger.error("✗ DM message link generation failed!")
-        return False
-    
-    # Create and store a test message
+
+    assert dm_link == expected_dm_link, f"DM message link generation failed! Expected: {expected_dm_link}, Got: {dm_link}"
+    logger.info("✓ DM message link generation works correctly!")
+
+    # Create and store a test message with unique ID
+    import uuid
+    unique_id = f"msg_{uuid.uuid4().hex[:8]}"
     test_message = {
-        "id": "msg456",
+        "id": unique_id,
         "author_id": "user1",
         "author_name": "TestUser1",
         "content": "This is a test message for link generation.",
         "created_at": today - timedelta(hours=1)
     }
-    
+
     success = store_message(
         message_id=test_message["id"],
         author_id=test_message["author_id"],
@@ -74,40 +70,31 @@ def test_message_links():
         guild_id=guild_id,
         guild_name="Test Guild"
     )
-    
-    if success:
-        logger.info(f"✓ Stored test message {test_message['id']}")
-    else:
-        logger.error(f"✗ Failed to store test message {test_message['id']}")
-        return False
-    
+
+    assert success, f"Failed to store test message {test_message['id']}"
+    logger.info(f"✓ Stored test message {test_message['id']}")
+
     # Retrieve messages and check they have the required fields
     messages = get_channel_messages_for_day(channel_id, today)
     logger.info(f"Retrieved {len(messages)} messages for the day")
-    
-    if not messages:
-        logger.warning("No messages found")
-        return False
-    
+
+    assert messages, "No messages found"
+
     # Check that messages include the required fields for link generation
     for msg in messages:
         logger.info(f"Message {msg.get('id', 'NO_ID')} fields: {list(msg.keys())}")
-        
+
         required_fields = ['id', 'guild_id', 'channel_id']
         missing_fields = [field for field in required_fields if field not in msg]
-        
-        if not missing_fields:
-            logger.info(f"✓ Message {msg['id']} has all required fields for link generation")
-            
-            # Generate a link for this message
-            msg_link = generate_discord_message_link(msg['guild_id'], msg['channel_id'], msg['id'])
-            logger.info(f"  Generated link: {msg_link}")
-        else:
-            logger.error(f"✗ Message missing required fields: {missing_fields}")
-            return False
-    
+
+        assert not missing_fields, f"Message missing required fields: {missing_fields}"
+        logger.info(f"✓ Message {msg['id']} has all required fields for link generation")
+
+        # Generate a link for this message
+        msg_link = generate_discord_message_link(msg['guild_id'], msg['channel_id'], msg['id'])
+        logger.info(f"  Generated link: {msg_link}")
+
     logger.info("✓ All tests passed!")
-    return True
 
 if __name__ == "__main__":
     success = test_message_links()


### PR DESCRIPTION
## 🚀 GitHub Actions Automated Testing Setup

This PR sets up automated testing infrastructure for the Discord bot using GitHub Actions.

### ✅ **Changes Made:**

#### Test Infrastructure Improvements:
- **Fixed pytest configuration** to address asyncio deprecation warnings
- **Updated test functions** to use proper pytest assertions instead of returns
- **Added unique test data generation** to prevent test conflicts between runs
- **Improved test reliability** and CI/CD readiness

#### Tests Improved:
- `test_database_init` - Database initialization testing
- `test_message_storage` - Message storage functionality testing  
- `test_message_links` - Discord message link generation testing

### 🧪 **Test Results:**
- ✅ **3 tests passing** consistently
- ✅ **No pytest warnings** (fixed asyncio deprecation issues)
- ✅ **Proper assertions** instead of return values
- ✅ **Unique test data** prevents conflicts

### 📋 **Next Steps After Merge:**

1. **Add GitHub Actions workflow file** (requires manual addition due to OAuth scope limitations):
   - Create `.github/workflows/test.yml` with the provided configuration
   - Workflow will test on Python 3.9, 3.10, and 3.11
   - Includes caching and test artifact uploads

2. **Optional: Enable integration tests** by adding repository secrets:
   - `DISCORD_BOT_TOKEN`
   - `OPENROUTER_API_KEY` 
   - `FIRECRAWL_API_KEY`
   - `APIFY_API_TOKEN`

### 🔧 **Technical Details:**

- **Pytest Configuration**: Fixed asyncio loop scope settings
- **Test Assertions**: Converted return-based tests to assertion-based
- **Data Isolation**: Added UUID-based unique identifiers for test data
- **CI/CD Ready**: All tests pass cleanly and are ready for automation

### 📊 **Testing:**
```bash
# All tests pass locally:
python -m pytest test_database.py test_message_links_simple.py -v
# Result: 3 passed in 0.05s
```

This PR establishes the foundation for automated testing and ensures all current tests are robust and reliable for CI/CD integration.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author