### PR TITLE
Update default model from grok-3-mini-beta to grok-3-mini

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ if not openrouter:
 # LLM Model Configuration (optional)
 # Environment variable: LLM_MODEL
 # Default model is "x-ai/grok-3-mini-beta"
-llm_model = os.getenv('LLM_MODEL', 'x-ai/grok-3-mini-beta:online')
+llm_model = os.getenv('LLM_MODEL', 'x-ai/grok-3-mini')
 
 # Rate Limiting Configuration (optional)
 # Environment variables: RATE_LIMIT_SECONDS, MAX_REQUESTS_PER_MINUTE


### PR DESCRIPTION
## Summary
- Update default LLM model from `x-ai/grok-3-mini-beta:online` to `x-ai/grok-3-mini`
- This change affects the default model used when `LLM_MODEL` environment variable is not set

## Test plan
- [x] Verify bot starts successfully with new default model
- [ ] Test bot responses to ensure model works correctly
- [ ] Confirm environment variable override still works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AI model configuration to use a new model identifier when no environment variable is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->