### PR TITLE
fix: allow thread messages in links-dump channel

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -170,7 +170,18 @@ async def handle_links_dump_channel(message: discord.Message) -> bool:
         if not hasattr(config, 'links_dump_channel_id') or not config.links_dump_channel_id:
             return False
             
-        if str(message.channel.id) != config.links_dump_channel_id:
+        # Check if this is the links dump channel or a thread within it
+        is_links_dump_channel = False
+        
+        if str(message.channel.id) == config.links_dump_channel_id:
+            # Direct message in the links dump channel
+            is_links_dump_channel = True
+        elif isinstance(message.channel, discord.Thread) and str(message.channel.parent_id) == config.links_dump_channel_id:
+            # Message in a thread created from the links dump channel - allow these
+            logger.info(f"Message {message.id} is in a thread from links dump channel, allowing")
+            return False
+            
+        if not is_links_dump_channel:
             return False
             
         # Don't handle bot messages or commands


### PR DESCRIPTION
Previously, messages in threads created from links-dump channel messages were incorrectly treated as direct channel messages, triggering the "links only" moderation rule. Now threads from links-dump are properly allowed for normal conversation.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of messages in threads under the links dump channel, ensuring these messages are now correctly permitted and not mistakenly deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->