### PR TITLE
Fix GIF rate limit double-counting on embed resolution

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -620,9 +620,12 @@ async def on_message_edit(before: discord.Message, after: discord.Message):
     if after.author == bot.user or after.author.bot:
         return
 
-    # Only enforce if the message NOW contains a GIF (didn't before, or still does)
-    if message_contains_gif(after):
-        # Reuse the same enforcement logic by treating it as a new message check
+    # Only enforce if a NEW GIF was added (didn't contain GIF before, but does now)
+    before_had_gif = message_contains_gif(before)
+    after_has_gif = message_contains_gif(after)
+
+    if after_has_gif and not before_had_gif:
+        # A GIF was added via edit - treat as a new GIF post
         await on_message(after)
 
 # Helper function for slash command handling


### PR DESCRIPTION
## Problem

Users were getting rate-limited for GIFs even when posting them hours apart. 

### Root Cause

1. When a user posts a message with a GIF URL (e.g., Tenor, Giphy), Discord doesn't always resolve the embed immediately
2. The initial `on_message` event fires and records the GIF in the rate limit history
3. **Hours later**, when Discord finally resolves the embed, it triggers an `on_message_edit` event
4. The old code would call `on_message(after)` again, which would:
   - Call `check_and_record_gif_post()` again
   - Add a **second timestamp** to the user's history for the same GIF
5. Now the user has 2 entries in their 15-minute window, so they're blocked from posting any more GIFs

## Solution

Modified the `on_message_edit` handler to only enforce GIF limits when a **NEW** GIF is added via edit, not when an existing GIF's embed is just being resolved.

### Changes

- Added before/after comparison in `on_message_edit` to detect actual GIF additions vs embed updates
- Only calls `on_message(after)` when `after_has_gif and not before_had_gif`

### Benefits

✅ Prevents double-counting of GIFs when embeds resolve
✅ Still catches attempts to bypass rate limits via message edits
✅ Users can now post GIFs at the correct 15-minute interval without false rate limiting

## Testing

This fix should resolve the issue where users posting GIFs hours apart were still getting rate-limited and having their messages deleted.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message edit handling to only trigger processing when new GIFs are added to edited messages, preventing unnecessary re-processing of existing GIFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->