### PR TITLE
Fix channel summary display issue

### DIFF
--- a/database.py
+++ b/database.py
@@ -620,7 +620,8 @@ def get_messages_for_time_range(start_time: datetime, end_time: datetime) -> Dic
                 """
                 SELECT
                     id, author_id, author_name, channel_id, channel_name,
-                    guild_id, guild_name, content, created_at, is_bot, is_command
+                    guild_id, guild_name, content, created_at, is_bot, is_command,
+                    scraped_url, scraped_content_summary, scraped_content_key_points
                 FROM messages
                 WHERE created_at BETWEEN ? AND ?
                 ORDER BY channel_id, created_at ASC
@@ -649,7 +650,10 @@ def get_messages_for_time_range(start_time: datetime, end_time: datetime) -> Dic
                     'content': row['content'],
                     'created_at': datetime.fromisoformat(row['created_at']),
                     'is_bot': bool(row['is_bot']),
-                    'is_command': bool(row['is_command'])
+                    'is_command': bool(row['is_command']),
+                    'scraped_url': row['scraped_url'],
+                    'scraped_content_summary': row['scraped_content_summary'],
+                    'scraped_content_key_points': row['scraped_content_key_points']
                 })
 
         total_messages = sum(len(channel_data['messages']) for channel_data in messages_by_channel.values())

--- a/summarization_tasks.py
+++ b/summarization_tasks.py
@@ -90,7 +90,10 @@ async def run_daily_summarization_once(now: datetime | None = None):
                         'is_bot': msg.get('is_bot', False),
                         'is_command': False,
                         'guild_id': guild_id,
-                        'channel_id': channel_id
+                        'channel_id': channel_id,
+                        'scraped_url': msg.get('scraped_url'),
+                        'scraped_content_summary': msg.get('scraped_content_summary'),
+                        'scraped_content_key_points': msg.get('scraped_content_key_points')
                     })
 
             if not formatted_messages:


### PR DESCRIPTION
The issue was that get_messages_for_time_range() was not retrieving the scraped content fields (scraped_url, scraped_content_summary, scraped_content_key_points) from the database, even though:
1. X/Twitter links were being scraped and stored correctly
2. The LLM handler had code to use scraped content
3. But the daily summary query didn't fetch these fields

Changes:
- Updated database.py get_messages_for_time_range() to include scraped content fields in the SELECT query and returned message dictionaries
- Updated summarization_tasks.py to pass scraped content fields to the LLM handler when formatting messages for daily summaries

Now when daily channel summaries are generated, they will include the actual scraped content from X/Twitter links rather than just the link text.