### PR TITLE
Reduce X reply count scraping calls

### DIFF
--- a/apify_handler.py
+++ b/apify_handler.py
@@ -121,7 +121,7 @@ async def fetch_tweet_replies(url: str) -> Optional[List[Dict[str, Any]]]:
         # Prepare the input for the Twitter Replies Scraper actor
         input_data = {
             "postUrls": [formatted_url],
-            "resultsLimit": 30
+            "resultsLimit": 10
         }
 
         # Use a separate thread for the blocking API call


### PR DESCRIPTION
Changed resultsLimit in fetch_tweet_replies from 30 to 10 to reduce API usage and improve performance.