### PR TITLE
Increase Function Performance

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,6 +26,11 @@ MAX_REQUESTS_PER_MINUTE=6
 # Get this from Firecrawl: https://firecrawl.dev
 FIRECRAWL_API_KEY=YOUR_FIRECRAWL_API_KEY
 
+# Firecrawl Timeout Configuration (optional)
+# Maximum duration in milliseconds before aborting a scrape request
+# Default: 900000ms (15 minutes) - maximum practical value
+FIRECRAWL_TIMEOUT_MS=900000
+
 # Apify API Token (optional, for x.com/twitter.com link scraping)
 # Get this from Apify: https://apify.com
 # If not provided, Twitter/X.com links will be processed using Firecrawl

--- a/config.py
+++ b/config.py
@@ -41,6 +41,12 @@ firecrawl_api_key = os.getenv('FIRECRAWL_API_KEY')
 if not firecrawl_api_key:
     raise ValueError("FIRECRAWL_API_KEY environment variable is required")
 
+# Firecrawl Timeout Configuration (optional)
+# Environment variable: FIRECRAWL_TIMEOUT_MS
+# Maximum duration in milliseconds before aborting a scrape request
+# Default: 900000ms (15 minutes) - maximum practical value
+firecrawl_timeout_ms = int(os.getenv('FIRECRAWL_TIMEOUT_MS', '900000'))
+
 # Apify API Token (optional, for x.com/twitter.com link scraping)
 # Environment variable: APIFY_API_TOKEN
 # If not provided, Twitter/X.com links will be processed using Firecrawl

--- a/firecrawl_handler.py
+++ b/firecrawl_handler.py
@@ -57,14 +57,14 @@ async def scrape_url_content(url: str) -> Optional[str]:
         def _do_scrape():
             # Preferred: new Firecrawl client with .scrape (v2)
             if hasattr(client, "scrape"):
-                return client.scrape(url, formats=["markdown"])  # type: ignore[call-arg]
+                return client.scrape(url, formats=["markdown"], timeout=config.firecrawl_timeout_ms)  # type: ignore[call-arg]
             # Legacy clients: use .scrape_url (v1)
             if hasattr(client, "scrape_url"):
-                return client.scrape_url(url, formats=["markdown"])  # type: ignore[call-arg]
+                return client.scrape_url(url, formats=["markdown"], timeout=config.firecrawl_timeout_ms)  # type: ignore[call-arg]
             # v1 compatibility shim on newer client
             v1_client = getattr(client, "v1", None)
             if v1_client is not None and hasattr(v1_client, "scrape_url"):
-                return v1_client.scrape_url(url, formats=["markdown"])  # type: ignore[call-arg]
+                return v1_client.scrape_url(url, formats=["markdown"], timeout=config.firecrawl_timeout_ms)  # type: ignore[call-arg]
             raise RuntimeError("Firecrawl client does not support scrape APIs")
 
         scrape_result = await loop.run_in_executor(None, _do_scrape)


### PR DESCRIPTION
- Add FIRECRAWL_TIMEOUT_MS configuration option (default: 900000ms / 15 minutes)
- Update firecrawl_handler.py to pass timeout parameter to all scrape methods
- Update .env.sample with timeout configuration and documentation
- Addresses timeout issues with slow-loading pages