### PR TITLE
feat: append point awards to daily summary threads

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,7 +43,8 @@ SUMMARY_HOUR=0
 SUMMARY_MINUTE=0
 # Channel ID to post daily channel summaries (optional)
 REPORTS_CHANNEL_ID=YOUR_CHANNEL_ID
-# Channel ID to post daily point awards (optional)
+# Channel ID where point awards will be appended to the daily summary (optional)
+# If not set, will auto-detect a channel named "general" or use the first active channel
 GENERAL_CHANNEL_ID=YOUR_GENERAL_CHANNEL_ID
 # Optional: restrict daily summaries to specific channel IDs (comma-separated)
 SUMMARY_CHANNEL_IDS=CHANNEL_ID_1,CHANNEL_ID_2


### PR DESCRIPTION
Point awards are now automatically appended to the end of the daily summary thread in the general channel. This makes point awards more visible and keeps all daily information in one place.

Changes:
- Restructured daily summarization to calculate points before posting summaries
- Modified post_summary_to_reports_channel() to accept optional point awards data
- Point awards are appended to the general channel's daily summary thread
- Auto-detection of general channel if GENERAL_CHANNEL_ID is not configured
- Falls back to first active channel if general channel cannot be detected
- Updated .env.sample documentation for GENERAL_CHANNEL_ID

The point awards section includes:
- 🏆 Daily Community Points header
- AI-generated summary of why points were awarded
- Total points distributed (X/50)
- List of recipients with points and reasons