### PR TITLE
Add black and white color options

### DIFF
--- a/config.py
+++ b/config.py
@@ -166,4 +166,7 @@ AVAILABLE_ROLE_COLORS = {
     'gold': '#FFD700',
     'gold-light': '#FFEC8B',
     'gold-dark': '#B8860B',
+    # Black & White
+    'black': '#000000',
+    'white': '#FFFFFF',
 }


### PR DESCRIPTION
Added black (#000000) and white (#FFFFFF) to the AVAILABLE_ROLE_COLORS dictionary, allowing users to set their name color to black or white.