### PR TITLE
automatic thread creation for extended conversations

### DIFF
--- a/auto_thread.py
+++ b/auto_thread.py
@@ -1,0 +1,462 @@
+"""
+Automatic thread creation for extended conversations.
+
+When two users reply back-and-forth N times consecutively in configured channels,
+their conversation is automatically moved to a thread to keep the main channel tidy.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Set, Tuple
+
+import discord
+
+import config
+
+logger = logging.getLogger('discord_bot.auto_thread')
+
+
+# =============================================================================
+# Data Structures
+# =============================================================================
+
+@dataclass
+class ConversationChain:
+    """Tracks a back-and-forth conversation between exactly 2 users."""
+    user_a_id: str
+    user_b_id: str
+    message_ids: List[str] = field(default_factory=list)
+    last_replier_id: str = ""
+    last_activity: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    first_message_id: str = ""
+
+    def get_users(self) -> Set[str]:
+        """Return the set of user IDs in this conversation."""
+        return {self.user_a_id, self.user_b_id}
+
+    def is_valid_next_reply(self, author_id: str) -> bool:
+        """Check if author_id is the expected next replier (alternating pattern)."""
+        if not self.last_replier_id:
+            return author_id in self.get_users()
+        # Must be one of the two users AND different from last replier
+        return author_id in self.get_users() and author_id != self.last_replier_id
+
+
+# =============================================================================
+# Conversation Tracker
+# =============================================================================
+
+class ConversationTracker:
+    """
+    In-memory tracker for ongoing conversations.
+
+    Tracking Strategy:
+    - Key conversations by the root message ID (first message in chain)
+    - When a reply comes in, find if it's replying to a message in an active chain
+    - Maintain a reverse lookup: message_id -> chain_root_id
+    """
+
+    def __init__(self, threshold: int = 5, ttl_minutes: int = 60):
+        self.threshold = threshold
+        self.ttl_minutes = ttl_minutes
+
+        # channel_id -> {root_message_id -> ConversationChain}
+        self._chains: Dict[str, Dict[str, ConversationChain]] = {}
+
+        # message_id -> (channel_id, root_message_id) for fast lookup
+        self._message_to_chain: Dict[str, Tuple[str, str]] = {}
+
+        # Track conversations being processed to prevent races
+        self._processing: Set[str] = set()
+
+    def _cleanup_expired(self, channel_id: str) -> None:
+        """Remove expired conversation chains."""
+        if channel_id not in self._chains:
+            return
+
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(minutes=self.ttl_minutes)
+
+        expired_roots = [
+            root_id for root_id, chain in self._chains[channel_id].items()
+            if chain.last_activity < cutoff
+        ]
+
+        for root_id in expired_roots:
+            chain = self._chains[channel_id].pop(root_id)
+            for msg_id in chain.message_ids:
+                self._message_to_chain.pop(msg_id, None)
+            logger.debug(f"Expired conversation chain {root_id} in channel {channel_id}")
+
+    def track_reply(
+        self,
+        channel_id: str,
+        message_id: str,
+        author_id: str,
+        reply_to_message_id: str
+    ) -> Optional[ConversationChain]:
+        """
+        Track a reply message and return the chain if threshold is met.
+
+        Returns:
+            ConversationChain if threshold reached, None otherwise
+        """
+        # Periodic cleanup
+        self._cleanup_expired(channel_id)
+
+        # Initialize channel dict if needed
+        if channel_id not in self._chains:
+            self._chains[channel_id] = {}
+
+        # Check if the replied-to message is in an existing chain
+        if reply_to_message_id in self._message_to_chain:
+            chain_channel, root_id = self._message_to_chain[reply_to_message_id]
+
+            if chain_channel == channel_id and root_id in self._chains[channel_id]:
+                chain = self._chains[channel_id][root_id]
+
+                # Skip if this chain is already being processed
+                if f"{channel_id}:{root_id}" in self._processing:
+                    return None
+
+                # Verify this is a valid alternating reply
+                if chain.is_valid_next_reply(author_id):
+                    # Add to chain
+                    chain.message_ids.append(message_id)
+                    chain.last_replier_id = author_id
+                    chain.last_activity = datetime.now(timezone.utc)
+                    self._message_to_chain[message_id] = (channel_id, root_id)
+
+                    logger.debug(
+                        f"Extended chain {root_id}: {len(chain.message_ids)} messages, "
+                        f"users {chain.user_a_id} <-> {chain.user_b_id}"
+                    )
+
+                    # Check threshold
+                    if len(chain.message_ids) >= self.threshold:
+                        return chain
+                    return None
+                else:
+                    # Someone else replied or same person replied twice
+                    # Don't remove chain - let it expire naturally or continue if valid reply comes
+                    logger.debug(
+                        f"Chain {root_id} not extended: author {author_id} "
+                        f"doesn't match alternating pattern"
+                    )
+                    return None
+
+        # This reply is not to a tracked message - will be handled by handler
+        # which may start a new chain
+        return None
+
+    def start_new_chain(
+        self,
+        channel_id: str,
+        original_message_id: str,
+        original_author_id: str,
+        reply_message_id: str,
+        reply_author_id: str
+    ) -> None:
+        """Start tracking a new conversation chain."""
+        if channel_id not in self._chains:
+            self._chains[channel_id] = {}
+
+        # Don't start if original message is already in a chain
+        if original_message_id in self._message_to_chain:
+            return
+
+        chain = ConversationChain(
+            user_a_id=original_author_id,
+            user_b_id=reply_author_id,
+            message_ids=[original_message_id, reply_message_id],
+            last_replier_id=reply_author_id,
+            first_message_id=original_message_id
+        )
+
+        self._chains[channel_id][original_message_id] = chain
+        self._message_to_chain[original_message_id] = (channel_id, original_message_id)
+        self._message_to_chain[reply_message_id] = (channel_id, original_message_id)
+
+        logger.debug(
+            f"Started new chain {original_message_id}: "
+            f"{original_author_id} <-> {reply_author_id}"
+        )
+
+    def mark_processing(self, channel_id: str, root_id: str) -> bool:
+        """Mark a chain as being processed. Returns False if already processing."""
+        key = f"{channel_id}:{root_id}"
+        if key in self._processing:
+            return False
+        self._processing.add(key)
+        return True
+
+    def unmark_processing(self, channel_id: str, root_id: str) -> None:
+        """Remove processing mark."""
+        key = f"{channel_id}:{root_id}"
+        self._processing.discard(key)
+
+    def remove_chain(self, channel_id: str, root_id: str) -> None:
+        """Remove a processed chain."""
+        if channel_id in self._chains and root_id in self._chains[channel_id]:
+            chain = self._chains[channel_id].pop(root_id)
+            for msg_id in chain.message_ids:
+                self._message_to_chain.pop(msg_id, None)
+        self.unmark_processing(channel_id, root_id)
+
+
+# =============================================================================
+# Auto Thread Handler
+# =============================================================================
+
+class AutoThreadHandler:
+    """Handles automatic thread creation for extended conversations."""
+
+    def __init__(self, bot: discord.Client):
+        self.bot = bot
+        self.tracker = ConversationTracker(
+            threshold=getattr(config, 'AUTO_THREAD_REPLY_THRESHOLD', 5),
+            ttl_minutes=getattr(config, 'AUTO_THREAD_TTL_MINUTES', 60)
+        )
+
+    def is_enabled_channel(self, channel_id: str) -> bool:
+        """Check if auto-threading is enabled for this channel."""
+        channel_ids = getattr(config, 'auto_thread_channel_ids', None)
+        if not channel_ids:
+            return False
+        return channel_id in channel_ids
+
+    async def handle_message(self, message: discord.Message) -> bool:
+        """
+        Process a message for auto-threading.
+
+        Returns True if a thread was created, False otherwise.
+        """
+        # Skip bots
+        if message.author.bot:
+            return False
+
+        # Skip messages in threads (only track main channel)
+        if isinstance(message.channel, discord.Thread):
+            return False
+
+        # Check if channel is enabled
+        channel_id = str(message.channel.id)
+        if not self.is_enabled_channel(channel_id):
+            return False
+
+        # Skip if not a reply
+        if not message.reference or not message.reference.message_id:
+            return False
+
+        reply_to_id = str(message.reference.message_id)
+        author_id = str(message.author.id)
+        message_id = str(message.id)
+
+        # Try to extend existing chain
+        chain = self.tracker.track_reply(
+            channel_id=channel_id,
+            message_id=message_id,
+            author_id=author_id,
+            reply_to_message_id=reply_to_id
+        )
+
+        if chain:
+            # Threshold reached - create thread
+            return await self._create_thread_for_chain(message.channel, chain)
+
+        # Check if this starts a new chain (reply to a message not in any chain)
+        if reply_to_id not in self.tracker._message_to_chain:
+            try:
+                ref_message = await self._fetch_referenced_message(message)
+                if ref_message and not ref_message.author.bot:
+                    ref_author_id = str(ref_message.author.id)
+                    ref_message_id = str(ref_message.id)
+
+                    # Only start chain if different users
+                    if ref_author_id != author_id:
+                        self.tracker.start_new_chain(
+                            channel_id=channel_id,
+                            original_message_id=ref_message_id,
+                            original_author_id=ref_author_id,
+                            reply_message_id=message_id,
+                            reply_author_id=author_id
+                        )
+            except Exception as e:
+                logger.warning(f"Failed to fetch referenced message: {e}")
+
+        return False
+
+    async def _fetch_referenced_message(
+        self,
+        message: discord.Message
+    ) -> Optional[discord.Message]:
+        """Fetch the message this is replying to."""
+        if not message.reference or not message.reference.message_id:
+            return None
+
+        # Try cache first
+        if message.reference.cached_message:
+            return message.reference.cached_message
+
+        try:
+            return await message.channel.fetch_message(message.reference.message_id)
+        except (discord.NotFound, discord.HTTPException) as e:
+            logger.debug(f"Could not fetch referenced message: {e}")
+            return None
+
+    async def _create_thread_for_chain(
+        self,
+        channel: discord.TextChannel,
+        chain: ConversationChain
+    ) -> bool:
+        """Create a thread and move the conversation into it."""
+        channel_id = str(channel.id)
+        root_id = chain.first_message_id
+
+        # Prevent concurrent processing
+        if not self.tracker.mark_processing(channel_id, root_id):
+            logger.debug(f"Chain {root_id} already being processed")
+            return False
+
+        try:
+            # Fetch all messages in the chain
+            messages: List[discord.Message] = []
+            for msg_id in chain.message_ids:
+                try:
+                    msg = await channel.fetch_message(int(msg_id))
+                    messages.append(msg)
+                except discord.NotFound:
+                    logger.warning(f"Message {msg_id} not found, skipping")
+                except discord.HTTPException as e:
+                    logger.warning(f"Failed to fetch message {msg_id}: {e}")
+
+            if len(messages) < 2:
+                logger.warning("Not enough messages to create thread")
+                self.tracker.unmark_processing(channel_id, root_id)
+                return False
+
+            # Get participant names for thread title
+            user_a = messages[0].author
+            user_b = next((m.author for m in messages if m.author.id != user_a.id), None)
+
+            if not user_b:
+                logger.warning("Could not find second participant")
+                self.tracker.unmark_processing(channel_id, root_id)
+                return False
+
+            # Create a standalone thread in the channel (not attached to a message)
+            # This allows us to delete ALL original messages from the main channel
+            thread_name = f"Conversation: {user_a.display_name} & {user_b.display_name}"
+            thread_name = thread_name[:100]  # Discord thread name limit
+
+            try:
+                thread = await channel.create_thread(
+                    name=thread_name,
+                    type=discord.ChannelType.public_thread,
+                    auto_archive_duration=1440  # 24 hours
+                )
+            except discord.HTTPException as e:
+                logger.error(f"Failed to create thread: {e}")
+                self.tracker.unmark_processing(channel_id, root_id)
+                return False
+
+            # Send introduction message
+            intro = (
+                f"This conversation between {user_a.mention} and {user_b.mention} "
+                f"has been moved to this thread to keep the main channel tidy.\n\n"
+                f"**Conversation history:**"
+            )
+            await thread.send(intro)
+
+            # Copy messages to thread with attribution
+            for msg in messages:
+                formatted = self._format_message_for_thread(msg)
+                await thread.send(formatted, allowed_mentions=discord.AllowedMentions.none())
+                await asyncio.sleep(0.5)  # Rate limit protection
+
+            # Final message inviting users to continue
+            await thread.send(
+                f"\n---\n{user_a.mention} {user_b.mention} "
+                f"Feel free to continue your conversation here!"
+            )
+
+            # Delete original messages from main channel
+            deleted_count = 0
+            for msg in messages:
+                try:
+                    await msg.delete()
+                    deleted_count += 1
+                    await asyncio.sleep(0.5)  # Rate limit protection
+                except discord.NotFound:
+                    pass  # Already deleted
+                except discord.Forbidden:
+                    logger.warning(f"No permission to delete message {msg.id}")
+                except discord.HTTPException as e:
+                    logger.warning(f"Failed to delete message {msg.id}: {e}")
+
+            logger.info(
+                f"Created thread '{thread_name}' with {len(messages)} messages, "
+                f"deleted {deleted_count} from channel"
+            )
+
+            # Clean up tracking
+            self.tracker.remove_chain(channel_id, root_id)
+            return True
+
+        except Exception as e:
+            logger.error(f"Error creating thread for chain {root_id}: {e}", exc_info=True)
+            self.tracker.unmark_processing(channel_id, root_id)
+            return False
+
+    def _format_message_for_thread(self, message: discord.Message) -> str:
+        """Format a message for reposting in the thread."""
+        timestamp = message.created_at.strftime("%H:%M")
+        author = message.author.display_name
+        content = message.content or "[No text content]"
+
+        # Handle attachments
+        attachments_text = ""
+        if message.attachments:
+            attachment_urls = [a.url for a in message.attachments]
+            attachments_text = "\n" + "\n".join(attachment_urls)
+
+        # Handle embeds (simplified - just note their presence)
+        embeds_text = ""
+        if message.embeds:
+            for embed in message.embeds:
+                if embed.url:
+                    embeds_text += f"\n[Embed: {embed.url}]"
+
+        return f"**{author}** ({timestamp}):\n{content}{attachments_text}{embeds_text}"
+
+
+# =============================================================================
+# Module-level instance (initialized in bot.py)
+# =============================================================================
+
+_handler: Optional[AutoThreadHandler] = None
+
+
+def init_auto_thread(bot: discord.Client) -> AutoThreadHandler:
+    """Initialize the auto-thread handler."""
+    global _handler
+    _handler = AutoThreadHandler(bot)
+    logger.info(
+        f"Auto-thread handler initialized "
+        f"(threshold={_handler.tracker.threshold}, ttl={_handler.tracker.ttl_minutes}min)"
+    )
+    return _handler
+
+
+def get_handler() -> Optional[AutoThreadHandler]:
+    """Get the initialized handler."""
+    return _handler
+
+
+async def handle_message_for_auto_thread(message: discord.Message) -> bool:
+    """Convenience function called from on_message."""
+    if _handler:
+        return await _handler.handle_message(message)
+    return False

--- a/config.py
+++ b/config.py
@@ -106,6 +106,24 @@ else:
 # Channel where only links are allowed - text messages will be auto-deleted
 links_dump_channel_id = os.getenv('LINKS_DUMP_CHANNEL_ID')
 
+# Auto Thread Configuration (optional)
+# Environment variable: AUTO_THREAD_CHANNEL_IDS
+# Comma-separated list of channel IDs where auto-threading is enabled
+# When two users reply back-and-forth N times, their conversation is moved to a thread
+_auto_thread_channel_ids_raw = os.getenv('AUTO_THREAD_CHANNEL_IDS')
+if _auto_thread_channel_ids_raw:
+    auto_thread_channel_ids = [cid.strip() for cid in _auto_thread_channel_ids_raw.split(',') if cid.strip()]
+else:
+    auto_thread_channel_ids = None
+
+# Reply threshold before creating thread (default: 5)
+# Environment variable: AUTO_THREAD_REPLY_THRESHOLD
+AUTO_THREAD_REPLY_THRESHOLD = int(os.getenv('AUTO_THREAD_REPLY_THRESHOLD', '5'))
+
+# Conversation timeout in minutes - chains expire after this inactivity (default: 60)
+# Environment variable: AUTO_THREAD_TTL_MINUTES
+AUTO_THREAD_TTL_MINUTES = int(os.getenv('AUTO_THREAD_TTL_MINUTES', '60'))
+
 # LLM API Configuration (optional)
 # Environment variable: PERPLEXITY_BASE_URL
 # Base URL for Perplexity API (or compatible API)

--- a/test_auto_thread.py
+++ b/test_auto_thread.py
@@ -1,0 +1,613 @@
+"""
+Tests for the auto_thread module.
+
+Tests conversation chain tracking and automatic thread creation logic.
+"""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Set up minimal environment variables before importing modules that need config
+os.environ.setdefault('DISCORD_BOT_TOKEN', 'test_token')
+os.environ.setdefault('EXA_API_KEY', 'test_key')
+os.environ.setdefault('XAI_API_KEY', 'test_key')
+os.environ.setdefault('FIRECRAWL_API_KEY', 'test_key')
+
+from auto_thread import (
+    ConversationChain,
+    ConversationTracker,
+    AutoThreadHandler,
+)
+
+
+class TestConversationChain(unittest.TestCase):
+    """Test the ConversationChain data class."""
+
+    def test_get_users_returns_both_users(self):
+        """Test that get_users returns both user IDs."""
+        chain = ConversationChain(user_a_id="123", user_b_id="456")
+        users = chain.get_users()
+        self.assertEqual(users, {"123", "456"})
+
+    def test_is_valid_next_reply_alternating_pattern(self):
+        """Test that alternating pattern is enforced."""
+        chain = ConversationChain(
+            user_a_id="123",
+            user_b_id="456",
+            last_replier_id="123"
+        )
+        # User 456 should be valid (alternating)
+        self.assertTrue(chain.is_valid_next_reply("456"))
+        # User 123 should not be valid (same user twice)
+        self.assertFalse(chain.is_valid_next_reply("123"))
+        # User 789 should not be valid (not in conversation)
+        self.assertFalse(chain.is_valid_next_reply("789"))
+
+    def test_is_valid_next_reply_empty_last_replier(self):
+        """Test that any conversation participant can reply if no last replier."""
+        chain = ConversationChain(
+            user_a_id="123",
+            user_b_id="456",
+            last_replier_id=""
+        )
+        self.assertTrue(chain.is_valid_next_reply("123"))
+        self.assertTrue(chain.is_valid_next_reply("456"))
+        self.assertFalse(chain.is_valid_next_reply("789"))
+
+
+class TestConversationTracker(unittest.TestCase):
+    """Test the ConversationTracker class."""
+
+    def test_start_new_chain(self):
+        """Test starting a new conversation chain."""
+        tracker = ConversationTracker(threshold=5)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+
+        # Chain should be created
+        self.assertIn("chan1", tracker._chains)
+        self.assertIn("msg1", tracker._chains["chan1"])
+
+        # Messages should be in reverse lookup
+        self.assertIn("msg1", tracker._message_to_chain)
+        self.assertIn("msg2", tracker._message_to_chain)
+
+        # Chain should have 2 messages
+        chain = tracker._chains["chan1"]["msg1"]
+        self.assertEqual(len(chain.message_ids), 2)
+        self.assertEqual(chain.user_a_id, "user1")
+        self.assertEqual(chain.user_b_id, "user2")
+
+    def test_start_new_chain_ignores_duplicate(self):
+        """Test that starting a chain with an already-tracked message is ignored."""
+        tracker = ConversationTracker(threshold=5)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+
+        # Try to start another chain with msg1
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user3",
+            reply_message_id="msg3",
+            reply_author_id="user4"
+        )
+
+        # Should still only have the original chain
+        self.assertEqual(len(tracker._chains["chan1"]), 1)
+        chain = tracker._chains["chan1"]["msg1"]
+        self.assertEqual(chain.user_a_id, "user1")
+        self.assertEqual(chain.user_b_id, "user2")
+
+    def test_track_reply_extends_chain(self):
+        """Test that track_reply extends an existing chain."""
+        tracker = ConversationTracker(threshold=5)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+
+        # user1 replies to msg2
+        result = tracker.track_reply(
+            channel_id="chan1",
+            message_id="msg3",
+            author_id="user1",
+            reply_to_message_id="msg2"
+        )
+
+        # Threshold not reached yet
+        self.assertIsNone(result)
+
+        # Chain should now have 3 messages
+        chain = tracker._chains["chan1"]["msg1"]
+        self.assertEqual(len(chain.message_ids), 3)
+        self.assertIn("msg3", chain.message_ids)
+
+    def test_track_reply_threshold_triggers(self):
+        """Test that reaching the threshold returns the chain."""
+        tracker = ConversationTracker(threshold=4)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+
+        # msg3: user1 replies to msg2
+        result = tracker.track_reply("chan1", "msg3", "user1", "msg2")
+        self.assertIsNone(result)  # 3 messages, need 4
+
+        # msg4: user2 replies to msg3 - this should hit threshold
+        result = tracker.track_reply("chan1", "msg4", "user2", "msg3")
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result.message_ids), 4)
+
+    def test_track_reply_rejects_same_user_twice(self):
+        """Test that the same user can't reply twice in a row."""
+        tracker = ConversationTracker(threshold=5)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+
+        # user2 tries to reply again (should fail - same user twice)
+        result = tracker.track_reply("chan1", "msg3", "user2", "msg2")
+        self.assertIsNone(result)
+
+        # Chain should still have only 2 messages
+        chain = tracker._chains["chan1"]["msg1"]
+        self.assertEqual(len(chain.message_ids), 2)
+
+    def test_track_reply_rejects_third_party(self):
+        """Test that a third user can't extend the chain."""
+        tracker = ConversationTracker(threshold=5)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+
+        # user3 tries to reply (should fail - not in conversation)
+        result = tracker.track_reply("chan1", "msg3", "user3", "msg2")
+        self.assertIsNone(result)
+
+        # Chain should still have only 2 messages
+        chain = tracker._chains["chan1"]["msg1"]
+        self.assertEqual(len(chain.message_ids), 2)
+
+    def test_track_reply_returns_none_for_untracked_message(self):
+        """Test that replying to an untracked message returns None."""
+        tracker = ConversationTracker(threshold=5)
+
+        # Reply to a message that's not being tracked
+        result = tracker.track_reply("chan1", "msg2", "user2", "msg1")
+        self.assertIsNone(result)
+
+    def test_cleanup_expired_chains(self):
+        """Test that expired chains are cleaned up."""
+        tracker = ConversationTracker(threshold=5, ttl_minutes=1)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+
+        # Manually expire the chain
+        chain = tracker._chains["chan1"]["msg1"]
+        chain.last_activity = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+        # Trigger cleanup via track_reply
+        tracker.track_reply("chan1", "msg3", "user1", "msg_unknown")
+
+        # Chain should be cleaned up
+        self.assertNotIn("msg1", tracker._chains.get("chan1", {}))
+        self.assertNotIn("msg1", tracker._message_to_chain)
+        self.assertNotIn("msg2", tracker._message_to_chain)
+
+    def test_mark_processing_prevents_duplicate(self):
+        """Test that mark_processing prevents concurrent processing."""
+        tracker = ConversationTracker()
+
+        # First mark should succeed
+        self.assertTrue(tracker.mark_processing("chan1", "msg1"))
+
+        # Second mark should fail
+        self.assertFalse(tracker.mark_processing("chan1", "msg1"))
+
+        # After unmarking, should succeed again
+        tracker.unmark_processing("chan1", "msg1")
+        self.assertTrue(tracker.mark_processing("chan1", "msg1"))
+
+    def test_remove_chain_cleans_up_fully(self):
+        """Test that remove_chain removes all tracking data."""
+        tracker = ConversationTracker(threshold=5)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="user1",
+            reply_message_id="msg2",
+            reply_author_id="user2"
+        )
+        tracker.track_reply("chan1", "msg3", "user1", "msg2")
+
+        tracker.remove_chain("chan1", "msg1")
+
+        # All tracking should be removed
+        self.assertNotIn("msg1", tracker._chains.get("chan1", {}))
+        self.assertNotIn("msg1", tracker._message_to_chain)
+        self.assertNotIn("msg2", tracker._message_to_chain)
+        self.assertNotIn("msg3", tracker._message_to_chain)
+
+
+class TestAutoThreadHandler(unittest.TestCase):
+    """Test the AutoThreadHandler class."""
+
+    def setUp(self):
+        """Set up mock bot and handler."""
+        self.mock_bot = MagicMock()
+        self.mock_bot.user = MagicMock()
+        self.mock_bot.user.id = 12345
+
+    @patch('auto_thread.config')
+    def test_is_enabled_channel_with_config(self, mock_config):
+        """Test is_enabled_channel returns True for configured channels."""
+        mock_config.auto_thread_channel_ids = ["chan1", "chan2"]
+        mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+        mock_config.AUTO_THREAD_TTL_MINUTES = 60
+
+        handler = AutoThreadHandler(self.mock_bot)
+
+        self.assertTrue(handler.is_enabled_channel("chan1"))
+        self.assertTrue(handler.is_enabled_channel("chan2"))
+        self.assertFalse(handler.is_enabled_channel("chan3"))
+
+    @patch('auto_thread.config')
+    def test_is_enabled_channel_without_config(self, mock_config):
+        """Test is_enabled_channel returns False when not configured."""
+        mock_config.auto_thread_channel_ids = None
+        mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+        mock_config.AUTO_THREAD_TTL_MINUTES = 60
+
+        handler = AutoThreadHandler(self.mock_bot)
+
+        self.assertFalse(handler.is_enabled_channel("chan1"))
+
+    def test_format_message_for_thread(self):
+        """Test message formatting for thread reposting."""
+        with patch('auto_thread.config') as mock_config:
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+            handler = AutoThreadHandler(self.mock_bot)
+
+        mock_message = MagicMock()
+        mock_message.author.display_name = "TestUser"
+        mock_message.content = "Hello world!"
+        mock_message.created_at = datetime(2024, 1, 15, 14, 30, 0)
+        mock_message.attachments = []
+        mock_message.embeds = []
+
+        result = handler._format_message_for_thread(mock_message)
+
+        self.assertIn("**TestUser**", result)
+        self.assertIn("14:30", result)
+        self.assertIn("Hello world!", result)
+
+    def test_format_message_with_attachments(self):
+        """Test message formatting with attachments."""
+        with patch('auto_thread.config') as mock_config:
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+            handler = AutoThreadHandler(self.mock_bot)
+
+        mock_attachment = MagicMock()
+        mock_attachment.url = "https://example.com/image.png"
+
+        mock_message = MagicMock()
+        mock_message.author.display_name = "TestUser"
+        mock_message.content = "Check this out"
+        mock_message.created_at = datetime(2024, 1, 15, 14, 30, 0)
+        mock_message.attachments = [mock_attachment]
+        mock_message.embeds = []
+
+        result = handler._format_message_for_thread(mock_message)
+
+        self.assertIn("https://example.com/image.png", result)
+
+    def test_format_message_with_no_content(self):
+        """Test message formatting when there's no text content."""
+        with patch('auto_thread.config') as mock_config:
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+            handler = AutoThreadHandler(self.mock_bot)
+
+        mock_message = MagicMock()
+        mock_message.author.display_name = "TestUser"
+        mock_message.content = ""
+        mock_message.created_at = datetime(2024, 1, 15, 14, 30, 0)
+        mock_message.attachments = []
+        mock_message.embeds = []
+
+        result = handler._format_message_for_thread(mock_message)
+
+        self.assertIn("[No text content]", result)
+
+    def test_format_message_with_embeds(self):
+        """Test message formatting with embeds."""
+        with patch('auto_thread.config') as mock_config:
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+            handler = AutoThreadHandler(self.mock_bot)
+
+        mock_embed = MagicMock()
+        mock_embed.url = "https://example.com/embedded"
+
+        mock_message = MagicMock()
+        mock_message.author.display_name = "TestUser"
+        mock_message.content = "Check this link"
+        mock_message.created_at = datetime(2024, 1, 15, 14, 30, 0)
+        mock_message.attachments = []
+        mock_message.embeds = [mock_embed]
+
+        result = handler._format_message_for_thread(mock_message)
+
+        self.assertIn("[Embed: https://example.com/embedded]", result)
+
+
+class TestConversationFlow(unittest.TestCase):
+    """Integration tests for full conversation flows."""
+
+    def test_full_conversation_reaches_threshold(self):
+        """Test a full conversation reaching the threshold."""
+        tracker = ConversationTracker(threshold=5)
+
+        # User A sends msg1 (original message - tracked when B replies)
+        # User B replies to msg1 (msg2) - starts chain
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="userA",
+            reply_message_id="msg2",
+            reply_author_id="userB"
+        )
+
+        # msg3: User A replies to msg2
+        result = tracker.track_reply("chan1", "msg3", "userA", "msg2")
+        self.assertIsNone(result)
+        self.assertEqual(len(tracker._chains["chan1"]["msg1"].message_ids), 3)
+
+        # msg4: User B replies to msg3
+        result = tracker.track_reply("chan1", "msg4", "userB", "msg3")
+        self.assertIsNone(result)
+        self.assertEqual(len(tracker._chains["chan1"]["msg1"].message_ids), 4)
+
+        # msg5: User A replies to msg4 - threshold reached!
+        result = tracker.track_reply("chan1", "msg5", "userA", "msg4")
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result.message_ids), 5)
+        self.assertEqual(result.user_a_id, "userA")
+        self.assertEqual(result.user_b_id, "userB")
+
+    def test_third_party_interjection_doesnt_break_chain(self):
+        """Test that third party replies don't break the chain."""
+        tracker = ConversationTracker(threshold=5)
+
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="userA",
+            reply_message_id="msg2",
+            reply_author_id="userB"
+        )
+
+        # msg3: User A replies to msg2
+        tracker.track_reply("chan1", "msg3", "userA", "msg2")
+
+        # msg4: User C replies to msg3 (third party - not extended but chain not broken)
+        result = tracker.track_reply("chan1", "msg4", "userC", "msg3")
+        self.assertIsNone(result)
+
+        # Chain should still have 3 messages (A, B, A)
+        chain = tracker._chains["chan1"]["msg1"]
+        self.assertEqual(len(chain.message_ids), 3)
+
+        # msg5: User B replies to msg3 (continuing original chain)
+        result = tracker.track_reply("chan1", "msg5", "userB", "msg3")
+        self.assertIsNone(result)
+
+        # Chain should now have 4 messages
+        chain = tracker._chains["chan1"]["msg1"]
+        self.assertEqual(len(chain.message_ids), 4)
+
+    def test_multiple_channels_tracked_independently(self):
+        """Test that conversations in different channels are tracked independently."""
+        tracker = ConversationTracker(threshold=3)
+
+        # Start chain in channel 1
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="userA",
+            reply_message_id="msg2",
+            reply_author_id="userB"
+        )
+
+        # Start chain in channel 2
+        tracker.start_new_chain(
+            channel_id="chan2",
+            original_message_id="msg10",
+            original_author_id="userX",
+            reply_message_id="msg11",
+            reply_author_id="userY"
+        )
+
+        # Extend channel 1
+        result1 = tracker.track_reply("chan1", "msg3", "userA", "msg2")
+
+        # Extend channel 2
+        result2 = tracker.track_reply("chan2", "msg12", "userX", "msg11")
+
+        # Both should hit threshold
+        self.assertIsNotNone(result1)
+        self.assertIsNotNone(result2)
+
+        # Verify they're independent chains
+        self.assertEqual(result1.user_a_id, "userA")
+        self.assertEqual(result2.user_a_id, "userX")
+
+    def test_chain_expires_and_can_restart(self):
+        """Test that an expired chain allows a new chain to start."""
+        tracker = ConversationTracker(threshold=5, ttl_minutes=1)
+
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg1",
+            original_author_id="userA",
+            reply_message_id="msg2",
+            reply_author_id="userB"
+        )
+
+        # Expire the chain
+        chain = tracker._chains["chan1"]["msg1"]
+        chain.last_activity = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+        # Trigger cleanup
+        tracker._cleanup_expired("chan1")
+
+        # Now we should be able to start a new chain with msg1
+        # (though in practice msg1 is a different message conceptually)
+        tracker.start_new_chain(
+            channel_id="chan1",
+            original_message_id="msg100",
+            original_author_id="userC",
+            reply_message_id="msg101",
+            reply_author_id="userD"
+        )
+
+        self.assertIn("msg100", tracker._chains["chan1"])
+        self.assertEqual(tracker._chains["chan1"]["msg100"].user_a_id, "userC")
+
+
+class TestAsyncHandlerMethods(unittest.TestCase):
+    """Test async methods of AutoThreadHandler using asyncio."""
+
+    def setUp(self):
+        """Set up mock bot."""
+        self.mock_bot = MagicMock()
+        self.mock_bot.user = MagicMock()
+        self.mock_bot.user.id = 12345
+
+    def test_handle_message_skips_bots(self):
+        """Test that bot messages are skipped."""
+        import asyncio
+
+        with patch('auto_thread.config') as mock_config:
+            mock_config.auto_thread_channel_ids = ["123"]
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+
+            handler = AutoThreadHandler(self.mock_bot)
+
+            mock_message = MagicMock()
+            mock_message.author.bot = True
+
+            result = asyncio.get_event_loop().run_until_complete(
+                handler.handle_message(mock_message)
+            )
+            self.assertFalse(result)
+
+    def test_handle_message_skips_threads(self):
+        """Test that messages in threads are skipped."""
+        import asyncio
+        import discord
+
+        with patch('auto_thread.config') as mock_config:
+            mock_config.auto_thread_channel_ids = ["123"]
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+
+            handler = AutoThreadHandler(self.mock_bot)
+
+            mock_message = MagicMock()
+            mock_message.author.bot = False
+            mock_message.channel = MagicMock(spec=discord.Thread)
+            mock_message.channel.id = 123
+
+            result = asyncio.get_event_loop().run_until_complete(
+                handler.handle_message(mock_message)
+            )
+            self.assertFalse(result)
+
+    def test_handle_message_skips_non_replies(self):
+        """Test that non-reply messages are skipped."""
+        import asyncio
+
+        with patch('auto_thread.config') as mock_config:
+            mock_config.auto_thread_channel_ids = ["123"]
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+
+            handler = AutoThreadHandler(self.mock_bot)
+
+            mock_message = MagicMock()
+            mock_message.author.bot = False
+            mock_message.channel = MagicMock()
+            mock_message.channel.__class__.__name__ = "TextChannel"
+            mock_message.channel.id = 123
+            mock_message.reference = None
+
+            result = asyncio.get_event_loop().run_until_complete(
+                handler.handle_message(mock_message)
+            )
+            self.assertFalse(result)
+
+    def test_handle_message_skips_disabled_channels(self):
+        """Test that messages in non-enabled channels are skipped."""
+        import asyncio
+
+        with patch('auto_thread.config') as mock_config:
+            mock_config.auto_thread_channel_ids = ["999"]  # Different channel
+            mock_config.AUTO_THREAD_REPLY_THRESHOLD = 5
+            mock_config.AUTO_THREAD_TTL_MINUTES = 60
+
+            handler = AutoThreadHandler(self.mock_bot)
+
+            mock_message = MagicMock()
+            mock_message.author.bot = False
+            mock_message.channel = MagicMock()
+            mock_message.channel.__class__.__name__ = "TextChannel"
+            mock_message.channel.id = 123
+            mock_message.reference = MagicMock()
+            mock_message.reference.message_id = 456
+
+            result = asyncio.get_event_loop().run_until_complete(
+                handler.handle_message(mock_message)
+            )
+            self.assertFalse(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When two users reply back-and-forth 5 times in configured channels, their conversation is automatically moved to a thread to keep the main channel clean.

Features:
- Configurable channels via AUTO_THREAD_CHANNEL_IDS env var
- Configurable threshold (default 5) and TTL (default 60 min)
- Copies all conversation messages to new thread with attribution
- Deletes original messages from main channel
- Only tracks alternating reply patterns between exactly 2 users
- Ignores third-party messages and bot messages

New files:
- auto_thread.py: ConversationTracker and AutoThreadHandler
- test_auto_thread.py: 27 unit tests


https://github.com/aj47/techfren-discord-bot/issues/71