### PR TITLE
Change link summarization trigger from thumbs up to magnifying glass emoji

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1292,7 +1292,7 @@ _summarized_message_ids = {}
 _SUMMARIZED_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 
 # Track messages currently being processed to prevent race conditions
-# This prevents duplicate summarizations when multiple 👍 events arrive close together
+# This prevents duplicate summarizations when multiple 🔍 events arrive close together
 _processing_message_ids = set()
 
 
@@ -1357,11 +1357,11 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
     Using on_raw_reaction_add instead of on_reaction_add ensures this works
     for messages not in the bot's cache (e.g., older messages or after restart).
 
-    Links are summarized when a thumbs up (👍) reaction is added to a message containing links.
+    Links are summarized when a magnifying glass (🔍) reaction is added to a message containing links.
     This ensures only community-approved links are summarized.
     """
-    # Only process thumbs up reactions
-    if str(payload.emoji) != '👍':
+    # Only process magnifying glass reactions
+    if str(payload.emoji) != '🔍':
         return
 
     # Skip if already successfully processed this message
@@ -1395,20 +1395,20 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
     if not urls:
         return
 
-    # Count thumbs up reactions
-    thumbs_up_count = 0
+    # Count magnifying glass reactions
+    mag_count = 0
     for r in message.reactions:
-        if str(r.emoji) == '👍':
-            thumbs_up_count = r.count
+        if str(r.emoji) == '🔍':
+            mag_count = r.count
             break
 
-    # Check trigger condition: 1+ thumbs up reaction
-    community_triggered = thumbs_up_count >= 1
+    # Check trigger condition: 1+ magnifying glass reaction
+    community_triggered = mag_count >= 1
 
     if not community_triggered:
         return
 
-    trigger_reason = f"{thumbs_up_count} thumbs up"
+    trigger_reason = f"{mag_count} mag reaction(s)"
     logger.info(f"Link summarization triggered by {trigger_reason} for message {message.id}")
 
     # Mark as processing to prevent race conditions from concurrent reaction events


### PR DESCRIPTION
## Summary
Updated the link summarization feature to use the magnifying glass (🔍) emoji as the trigger reaction instead of the thumbs up (👍) emoji. This change affects both the reaction detection logic and all related comments and variable names.

## Key Changes
- Changed the trigger emoji from `👍` (thumbs up) to `🔍` (magnifying glass) for link summarization
- Updated reaction detection logic in `on_raw_reaction_add()` to check for the magnifying glass emoji
- Renamed internal variable `thumbs_up_count` to `mag_count` for clarity
- Updated all related comments to reference the magnifying glass emoji instead of thumbs up
- Updated the trigger reason log message from "thumbs up" to "mag reaction(s)"

## Implementation Details
- The magnifying glass emoji is now checked as the sole trigger for link summarization
- The threshold remains at 1+ reactions to trigger summarization
- All documentation and logging has been updated to reflect the new emoji choice
- No changes to the core summarization logic or race condition prevention mechanism

https://claude.ai/code/session_011Bc6H94xPgCo3at4rM7LFz