### PR TITLE
Fix links dump channel blocking thread creation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -661,6 +661,10 @@ async def handle_links_dump_channel(message: discord.Message) -> bool:
         if message.author.bot:
             return False
 
+        # Allow system messages (thread creation notifications, pins, etc.)
+        if message.type not in (discord.MessageType.default, discord.MessageType.reply):
+            return False
+
         # Check for URLs in the message content using the same regex as process_url
         url_pattern = r'https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+(?:/[^\s]*)?(?:\?[^\s]*)?'
         urls = re.findall(url_pattern, message.content)


### PR DESCRIPTION
## Problem

When a user creates a thread in the links dump channel, Discord posts a system message (type thread_created) in the parent channel. This system message contains no URL, so the bot was incorrectly treating it as a text-only message, deleting it and showing the warning.

## Fix

Skip all system messages (thread creation, pins, etc.) in the links dump handler. Only enforce the links-only rule on regular messages (default) and replies (reply).