### PR TITLE
Make general daily summary cover all active channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The bot automatically generates summaries for all active channels once per day:
 
 - Runs at a configurable time (default: midnight UTC)
 - Summarizes messages from the past 24 hours for each active channel
+- The summary posted in the configured general channel is a server-wide digest of all active channels
 - Stores summaries in a dedicated database table with metadata including:
   - Channel information
   - Message count
@@ -140,7 +141,7 @@ To configure the automated summarization:
 # In .env file or environment variables
 SUMMARY_HOUR=0  # Hour of the day to run summarization (UTC, 0-23)
 SUMMARY_MINUTE=0  # Minute of the hour to run summarization (0-59)
-SUMMARY_CHANNEL_IDS=CHANNEL_ID_1,CHANNEL_ID_2  # Optional: restrict daily summaries to specific channels (comma-separated)
+SUMMARY_CHANNEL_IDS=CHANNEL_ID_1,CHANNEL_ID_2  # Optional: restrict per-channel daily summaries (general digest still uses all active channels)
 ```
 
 ## Database

--- a/config.py
+++ b/config.py
@@ -94,7 +94,8 @@ summary_minute = int(os.getenv('SUMMARY_MINUTE', '0'))
 reports_channel_id = os.getenv('REPORTS_CHANNEL_ID')
 general_channel_id = os.getenv('GENERAL_CHANNEL_ID')
 
-# Optional: restrict daily summaries to specific channel IDs (comma-separated list of IDs)
+# Optional: restrict per-channel daily summaries to specific channel IDs (comma-separated list of IDs).
+# The daily summary posted in GENERAL_CHANNEL_ID still uses all active channels as a server-wide digest.
 _summary_channel_ids_raw = os.getenv('SUMMARY_CHANNEL_IDS')
 if _summary_channel_ids_raw:
     summary_channel_ids = [cid.strip() for cid in _summary_channel_ids_raw.split(',') if cid.strip()]

--- a/config.sample.py
+++ b/config.sample.py
@@ -56,5 +56,5 @@ apify_api_token = "YOUR_APIFY_API_TOKEN"
 summary_hour = 0
 summary_minute = 0
 reports_channel_id = "YOUR_CHANNEL_ID"  # For channel summaries
-general_channel_id = "YOUR_GENERAL_CHANNEL_ID"  # For daily point awards
-summary_channel_ids = ["YOUR_CHANNEL_ID_1", "YOUR_CHANNEL_ID_2"]  # Optional: restrict summaries to specific channels
+general_channel_id = "YOUR_GENERAL_CHANNEL_ID"  # For the server-wide daily digest and point awards
+summary_channel_ids = ["YOUR_CHANNEL_ID_1", "YOUR_CHANNEL_ID_2"]  # Optional: restrict per-channel summaries

--- a/database.py
+++ b/database.py
@@ -893,7 +893,7 @@ def delete_messages_older_than(cutoff_time: datetime) -> int:
 
 def get_active_channels(hours: int = 24) -> List[Dict[str, Any]]:
     """
-    Get a list of channels that have had activity in the last specified hours.
+    Get channels with non-bot, non-command activity in the last specified hours.
 
     Args:
         hours (int): Number of hours to look back for activity
@@ -919,6 +919,8 @@ def get_active_channels(hours: int = 24) -> List[Dict[str, Any]]:
                     COUNT(*) as message_count
                 FROM messages
                 WHERE created_at >= ?
+                AND is_bot = 0
+                AND is_command = 0
                 GROUP BY channel_id
                 ORDER BY message_count DESC
                 """,

--- a/llm_handler.py
+++ b/llm_handler.py
@@ -417,6 +417,10 @@ async def call_llm_for_summary(messages, channel_name, date, hours=24):
             message_id = msg.get('id', '')
             guild_id = msg.get('guild_id', '')
             channel_id = msg.get('channel_id', '')
+            message_channel_name = msg.get('channel_name')
+            channel_prefix = ""
+            if message_channel_name and str(message_channel_name).lower() != str(channel_name).lower():
+                channel_prefix = f"#{message_channel_name} | "
 
             # Generate Discord message link
             message_link = ""
@@ -437,9 +441,9 @@ async def call_llm_for_summary(messages, channel_name, date, hours=24):
             timestamp_marker = f" [TIMESTAMP:{discord_timestamp}]" if discord_timestamp else ""
             if message_link:
                 # Format as clickable Discord link that the LLM will understand
-                message_text = f"[{time_str}]{timestamp_marker} {author_name}: {content} [Jump to message]({message_link})"
+                message_text = f"[{time_str}]{timestamp_marker} {channel_prefix}{author_name}: {content} [Jump to message]({message_link})"
             else:
-                message_text = f"[{time_str}]{timestamp_marker} {author_name}: {content}"
+                message_text = f"[{time_str}]{timestamp_marker} {channel_prefix}{author_name}: {content}"
 
             # If there are image descriptions, add them inline to the message
             if image_descriptions:
@@ -488,7 +492,8 @@ async def call_llm_for_summary(messages, channel_name, date, hours=24):
 
         # Create the prompt for the LLM
         time_period = "24 hours" if hours == 24 else f"{hours} hours" if hours != 1 else "1 hour"
-        prompt = f"""Summarize the #{channel_name} channel for the past {time_period}. Extract SIGNAL from noise.
+        summary_subject = "all active channels" if channel_name == "all active channels" else f"#{channel_name} channel"
+        prompt = f"""Summarize {summary_subject} for the past {time_period}. Extract SIGNAL from noise.
 
 PRIORITIZE (in order):
 1. New tech news, product launches, announcements

--- a/summarization_tasks.py
+++ b/summarization_tasks.py
@@ -16,6 +16,25 @@ def set_discord_client(client_instance):
     global discord_client
     discord_client = client_instance
 
+def _format_daily_summary_message(msg, channel_data):
+    """Normalize a stored message for the daily summary/points LLM calls."""
+    return {
+        'id': msg.get('id', ''),
+        'author_id': msg.get('author_id', ''),
+        'author_name': msg['author_name'],
+        'content': msg['content'],
+        'created_at': msg['created_at'],
+        'is_bot': msg.get('is_bot', False),
+        'is_command': False,
+        'guild_id': channel_data['guild_id'],
+        'channel_id': channel_data['channel_id'],
+        'channel_name': channel_data['channel_name'],
+        'scraped_url': msg.get('scraped_url'),
+        'scraped_content_summary': msg.get('scraped_content_summary'),
+        'scraped_content_key_points': msg.get('scraped_content_key_points'),
+        'image_descriptions': msg.get('image_descriptions')
+    }
+
 async def run_daily_summarization_once(now: datetime | None = None):
     """Run the daily channel summarization logic a single time.
 
@@ -34,11 +53,16 @@ async def run_daily_summarization_once(now: datetime | None = None):
         yesterday = now - timedelta(hours=24)
 
         # Get active channels from the past 24 hours
-        active_channels = database.get_active_channels(hours=24)
+        all_active_channels = database.get_active_channels(hours=24)
 
-        if not active_channels:
+        if not all_active_channels:
             logger.info("No active channels found in the past 24 hours. Skipping summarization.")
             return
+
+        # These are the per-channel summary targets. The general-channel summary
+        # is handled specially below and uses all_active_channels so it can act as
+        # a server-wide digest even when per-channel summaries are allowlisted.
+        active_channels = list(all_active_channels)
 
         # If specific channels are configured, filter to just those
         summary_channel_ids = getattr(config, 'summary_channel_ids', None)
@@ -50,8 +74,7 @@ async def run_daily_summarization_once(now: datetime | None = None):
             ]
 
             if not active_channels:
-                logger.info("No configured summary channels had activity in the past 24 hours. Skipping summarization.")
-                return
+                logger.info("No configured summary channels had activity in the past 24 hours. Will still attempt the all-channel general summary.")
 
         logger.info(f"Found {len(active_channels)} active channels to summarize")
 
@@ -66,12 +89,11 @@ async def run_daily_summarization_once(now: datetime | None = None):
         all_messages_for_points = []
 
         # First pass: collect all messages for point analysis
-        for channel_data in active_channels:
+        for channel_data in all_active_channels:
             channel_id = channel_data['channel_id']
-            channel_name = channel_data['channel_name']
 
             if channel_id not in messages_by_channel:
-                logger.warning(f"No messages found for channel {channel_name} ({channel_id}) despite being marked as active")
+                logger.warning(f"No messages found for channel {channel_data['channel_name']} ({channel_id}) despite being marked as active")
                 continue
 
             channel_messages = messages_by_channel[channel_id]['messages']
@@ -79,24 +101,9 @@ async def run_daily_summarization_once(now: datetime | None = None):
             if not channel_messages:
                 continue
 
-            guild_id = channel_data['guild_id']
-
             for msg in channel_messages:
                 if not msg.get('is_command', False) and not msg.get('is_bot', False):
-                    formatted_msg = {
-                        'id': msg.get('id', ''),
-                        'author_id': msg.get('author_id', ''),
-                        'author_name': msg['author_name'],
-                        'content': msg['content'],
-                        'created_at': msg['created_at'],
-                        'is_bot': msg.get('is_bot', False),
-                        'is_command': False,
-                        'guild_id': guild_id,
-                        'channel_id': channel_id,
-                        'scraped_url': msg.get('scraped_url'),
-                        'scraped_content_summary': msg.get('scraped_content_summary'),
-                        'scraped_content_key_points': msg.get('scraped_content_key_points')
-                    }
+                    formatted_msg = _format_daily_summary_message(msg, channel_data)
                     all_messages_for_points.append(formatted_msg)
 
         # Award points based on contributions from the past 24 hours BEFORE posting summaries
@@ -175,55 +182,95 @@ async def run_daily_summarization_once(now: datetime | None = None):
             except Exception as e:
                 logger.error(f"Error awarding points: {str(e)}", exc_info=True)
 
+        # Build a server-wide message list for the summary posted in #general.
+        # This intentionally uses all active channels (not SUMMARY_CHANNEL_IDS),
+        # because #general should serve as the cross-channel daily digest.
+        all_channel_summary_messages = []
+        all_channel_names = []
+        for channel_data in all_active_channels:
+            channel_id = channel_data['channel_id']
+            if channel_id not in messages_by_channel:
+                continue
+
+            channel_messages = messages_by_channel[channel_id]['messages']
+            channel_formatted_messages = []
+            for msg in channel_messages:
+                if not msg.get('is_command', False):
+                    channel_formatted_messages.append(_format_daily_summary_message(msg, channel_data))
+
+            if channel_formatted_messages:
+                all_channel_summary_messages.extend(channel_formatted_messages)
+                all_channel_names.append(channel_data['channel_name'])
+
         # Now process each channel and post summaries (with point awards appended to general channel)
         general_channel_id = getattr(config, 'general_channel_id', None)
 
         # If GENERAL_CHANNEL_ID is not configured, try to find a channel named "general"
-        if not general_channel_id and active_channels:
-            for channel_data in active_channels:
+        if not general_channel_id and all_active_channels:
+            for channel_data in all_active_channels:
                 if channel_data['channel_name'].lower() == 'general':
                     general_channel_id = channel_data['channel_id']
                     logger.info(f"GENERAL_CHANNEL_ID not configured. Auto-detected general channel: {general_channel_id}")
                     break
 
         # If still not found, use the first active channel
-        if not general_channel_id and active_channels and point_awards_result:
-            general_channel_id = active_channels[0]['channel_id']
-            logger.info(f"GENERAL_CHANNEL_ID not configured. Using first active channel for point awards: {general_channel_id}")
+        if not general_channel_id and all_active_channels and (point_awards_result or all_channel_summary_messages):
+            general_channel_id = all_active_channels[0]['channel_id']
+            logger.info(f"GENERAL_CHANNEL_ID not configured. Using first active channel for daily digest/point awards: {general_channel_id}")
+
+        # Ensure the general channel gets a digest even if SUMMARY_CHANNEL_IDS does
+        # not include it or if it had no messages of its own in the past 24 hours.
+        if general_channel_id and all_channel_summary_messages:
+            has_general_target = any(str(ch['channel_id']) == str(general_channel_id) for ch in active_channels)
+            if not has_general_target:
+                general_channel_data = next(
+                    (ch for ch in all_active_channels if str(ch['channel_id']) == str(general_channel_id)),
+                    None
+                )
+                active_channels.append({
+                    'channel_id': str(general_channel_id),
+                    'channel_name': general_channel_data['channel_name'] if general_channel_data else 'general',
+                    'guild_id': general_channel_data['guild_id'] if general_channel_data else all_active_channels[0]['guild_id'],
+                    'guild_name': general_channel_data['guild_name'] if general_channel_data else all_active_channels[0]['guild_name'],
+                    'message_count': 0
+                })
 
         for channel_data in active_channels:
             channel_id = channel_data['channel_id']
             channel_name = channel_data['channel_name']
 
-            if channel_id not in messages_by_channel:
-                continue
-
-            channel_messages = messages_by_channel[channel_id]['messages']
-
-            if not channel_messages:
-                continue
-
             guild_id = channel_data['guild_id']
             guild_name = channel_data['guild_name']
 
-            formatted_messages = []
-            for msg in channel_messages:
-                if not msg.get('is_command', False):
-                    formatted_msg = {
-                        'id': msg.get('id', ''),
-                        'author_id': msg.get('author_id', ''),
-                        'author_name': msg['author_name'],
-                        'content': msg['content'],
-                        'created_at': msg['created_at'],
-                        'is_bot': msg.get('is_bot', False),
-                        'is_command': False,
-                        'guild_id': guild_id,
-                        'channel_id': channel_id,
-                        'scraped_url': msg.get('scraped_url'),
-                        'scraped_content_summary': msg.get('scraped_content_summary'),
-                        'scraped_content_key_points': msg.get('scraped_content_key_points')
-                    }
-                    formatted_messages.append(formatted_msg)
+            is_general_summary = general_channel_id and str(channel_id) == str(general_channel_id)
+
+            if channel_id not in messages_by_channel and not (is_general_summary and all_channel_summary_messages):
+                continue
+
+            if is_general_summary and all_channel_summary_messages:
+                formatted_messages = all_channel_summary_messages
+                summary_llm_channel_name = 'all active channels'
+                metadata_scope = 'all_active_channels'
+                logger.info(
+                    f"Generating general digest from {len(formatted_messages)} messages across "
+                    f"{len(all_channel_names)} channel(s): {', '.join(all_channel_names)}"
+                )
+            else:
+                if channel_id not in messages_by_channel:
+                    continue
+
+                channel_messages = messages_by_channel[channel_id]['messages']
+
+                if not channel_messages:
+                    continue
+
+                formatted_messages = []
+                for msg in channel_messages:
+                    if not msg.get('is_command', False):
+                        formatted_messages.append(_format_daily_summary_message(msg, channel_data))
+
+                summary_llm_channel_name = channel_name
+                metadata_scope = 'single_channel'
 
             if not formatted_messages:
                 logger.info(f"No non-command messages found for channel {channel_name}. Skipping summarization.")
@@ -232,12 +279,16 @@ async def run_daily_summarization_once(now: datetime | None = None):
             active_users = list(set(msg['author_name'] for msg in formatted_messages))
 
             try:
-                summary_text = await call_llm_for_summary(formatted_messages, channel_name, yesterday)
+                summary_text = await call_llm_for_summary(formatted_messages, summary_llm_channel_name, yesterday)
                 metadata = {
                     'start_time': yesterday.isoformat(),
                     'end_time': now.isoformat(),
-                    'summary_type': 'automated_daily'
+                    'summary_type': 'automated_daily',
+                    'summary_scope': metadata_scope
                 }
+                if metadata_scope == 'all_active_channels':
+                    metadata['included_channel_ids'] = [ch['channel_id'] for ch in all_active_channels]
+                    metadata['included_channel_names'] = all_channel_names
                 success = database.store_channel_summary(
                     channel_id=channel_id,
                     channel_name=channel_name,

--- a/summarization_tasks.py
+++ b/summarization_tasks.py
@@ -35,6 +35,10 @@ def _format_daily_summary_message(msg, channel_data):
         'image_descriptions': msg.get('image_descriptions')
     }
 
+def _is_human_summary_message(msg):
+    """Return True for messages that should be summarized in automated digests."""
+    return not msg.get('is_command', False) and not msg.get('is_bot', False)
+
 async def run_daily_summarization_once(now: datetime | None = None):
     """Run the daily channel summarization logic a single time.
 
@@ -102,7 +106,7 @@ async def run_daily_summarization_once(now: datetime | None = None):
                 continue
 
             for msg in channel_messages:
-                if not msg.get('is_command', False) and not msg.get('is_bot', False):
+                if _is_human_summary_message(msg):
                     formatted_msg = _format_daily_summary_message(msg, channel_data)
                     all_messages_for_points.append(formatted_msg)
 
@@ -182,56 +186,109 @@ async def run_daily_summarization_once(now: datetime | None = None):
             except Exception as e:
                 logger.error(f"Error awarding points: {str(e)}", exc_info=True)
 
-        # Build a server-wide message list for the summary posted in #general.
-        # This intentionally uses all active channels (not SUMMARY_CHANNEL_IDS),
-        # because #general should serve as the cross-channel daily digest.
-        all_channel_summary_messages = []
-        all_channel_names = []
-        for channel_data in all_active_channels:
-            channel_id = channel_data['channel_id']
-            if channel_id not in messages_by_channel:
-                continue
-
-            channel_messages = messages_by_channel[channel_id]['messages']
-            channel_formatted_messages = []
-            for msg in channel_messages:
-                if not msg.get('is_command', False):
-                    channel_formatted_messages.append(_format_daily_summary_message(msg, channel_data))
-
-            if channel_formatted_messages:
-                all_channel_summary_messages.extend(channel_formatted_messages)
-                all_channel_names.append(channel_data['channel_name'])
-
         # Now process each channel and post summaries (with point awards appended to general channel)
         general_channel_id = getattr(config, 'general_channel_id', None)
+        general_channel_data = None
+        general_guild_id = None
+        general_guild_name = None
+
+        if general_channel_id:
+            general_channel_data = next(
+                (ch for ch in all_active_channels if str(ch['channel_id']) == str(general_channel_id)),
+                None
+            )
+            if general_channel_data:
+                general_guild_id = str(general_channel_data.get('guild_id')) if general_channel_data.get('guild_id') else None
+                general_guild_name = general_channel_data.get('guild_name')
 
         # If GENERAL_CHANNEL_ID is not configured, try to find a channel named "general"
         if not general_channel_id and all_active_channels:
             for channel_data in all_active_channels:
                 if channel_data['channel_name'].lower() == 'general':
                     general_channel_id = channel_data['channel_id']
+                    general_channel_data = channel_data
+                    general_guild_id = str(channel_data.get('guild_id')) if channel_data.get('guild_id') else None
+                    general_guild_name = channel_data.get('guild_name')
                     logger.info(f"GENERAL_CHANNEL_ID not configured. Auto-detected general channel: {general_channel_id}")
                     break
 
+        has_human_summary_messages = any(
+            channel_data['channel_id'] in messages_by_channel and any(
+                _is_human_summary_message(msg)
+                for msg in messages_by_channel[channel_data['channel_id']]['messages']
+            )
+            for channel_data in all_active_channels
+        )
+
         # If still not found, use the first active channel
-        if not general_channel_id and all_active_channels and (point_awards_result or all_channel_summary_messages):
-            general_channel_id = all_active_channels[0]['channel_id']
+        if not general_channel_id and all_active_channels and (point_awards_result or has_human_summary_messages):
+            general_channel_data = all_active_channels[0]
+            general_channel_id = general_channel_data['channel_id']
+            general_guild_id = str(general_channel_data.get('guild_id')) if general_channel_data.get('guild_id') else None
+            general_guild_name = general_channel_data.get('guild_name')
             logger.info(f"GENERAL_CHANNEL_ID not configured. Using first active channel for daily digest/point awards: {general_channel_id}")
+
+        if general_channel_id and not general_guild_id:
+            try:
+                general_discord_channel = discord_client.get_channel(int(general_channel_id))
+            except (TypeError, ValueError):
+                general_discord_channel = None
+
+            general_discord_guild = getattr(general_discord_channel, 'guild', None) if general_discord_channel else None
+            if general_discord_guild and getattr(general_discord_guild, 'id', None):
+                general_guild_id = str(general_discord_guild.id)
+                general_guild_name = getattr(general_discord_guild, 'name', None)
+                if not general_channel_data:
+                    general_channel_data = {
+                        'channel_id': str(general_channel_id),
+                        'channel_name': getattr(general_discord_channel, 'name', 'general'),
+                        'guild_id': general_guild_id,
+                        'guild_name': general_guild_name,
+                        'message_count': 0
+                    }
+
+        # Build a server-wide message list for the summary posted in #general.
+        # This intentionally uses all active channels in the target guild (not
+        # SUMMARY_CHANNEL_IDS), so #general serves as a same-server daily digest
+        # without mixing content across guilds.
+        all_channel_summary_messages = []
+        all_channel_summary_channels = []
+        all_channel_names = []
+        if general_channel_id and general_guild_id:
+            for channel_data in all_active_channels:
+                if str(channel_data.get('guild_id')) != str(general_guild_id):
+                    continue
+
+                channel_id = channel_data['channel_id']
+                if channel_id not in messages_by_channel:
+                    continue
+
+                channel_messages = messages_by_channel[channel_id]['messages']
+                channel_formatted_messages = []
+                for msg in channel_messages:
+                    if _is_human_summary_message(msg):
+                        channel_formatted_messages.append(_format_daily_summary_message(msg, channel_data))
+
+                if channel_formatted_messages:
+                    all_channel_summary_messages.extend(channel_formatted_messages)
+                    all_channel_summary_channels.append(channel_data)
+                    all_channel_names.append(channel_data['channel_name'])
+        elif general_channel_id:
+            logger.warning(
+                f"Could not determine guild for general channel {general_channel_id}; "
+                "skipping all-channel general digest to avoid cross-guild content leakage."
+            )
 
         # Ensure the general channel gets a digest even if SUMMARY_CHANNEL_IDS does
         # not include it or if it had no messages of its own in the past 24 hours.
         if general_channel_id and all_channel_summary_messages:
             has_general_target = any(str(ch['channel_id']) == str(general_channel_id) for ch in active_channels)
             if not has_general_target:
-                general_channel_data = next(
-                    (ch for ch in all_active_channels if str(ch['channel_id']) == str(general_channel_id)),
-                    None
-                )
                 active_channels.append({
                     'channel_id': str(general_channel_id),
                     'channel_name': general_channel_data['channel_name'] if general_channel_data else 'general',
-                    'guild_id': general_channel_data['guild_id'] if general_channel_data else all_active_channels[0]['guild_id'],
-                    'guild_name': general_channel_data['guild_name'] if general_channel_data else all_active_channels[0]['guild_name'],
+                    'guild_id': general_guild_id,
+                    'guild_name': general_guild_name,
                     'message_count': 0
                 })
 
@@ -287,8 +344,9 @@ async def run_daily_summarization_once(now: datetime | None = None):
                     'summary_scope': metadata_scope
                 }
                 if metadata_scope == 'all_active_channels':
-                    metadata['included_channel_ids'] = [ch['channel_id'] for ch in all_active_channels]
+                    metadata['included_channel_ids'] = [ch['channel_id'] for ch in all_channel_summary_channels]
                     metadata['included_channel_names'] = all_channel_names
+                    metadata['included_guild_id'] = general_guild_id
                 success = database.store_channel_summary(
                     channel_id=channel_id,
                     channel_name=channel_name,

--- a/test_daily_general_summary.py
+++ b/test_daily_general_summary.py
@@ -1,0 +1,111 @@
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import summarization_tasks
+
+
+class TestDailyGeneralSummary(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.original_client = summarization_tasks.discord_client
+        summarization_tasks.set_discord_client(MagicMock())
+
+    async def asyncTearDown(self):
+        summarization_tasks.set_discord_client(self.original_client)
+
+    async def test_general_summary_uses_all_active_channels_even_when_per_channel_summaries_are_limited(self):
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc)
+        active_channels = [
+            {
+                "channel_id": "general_id",
+                "channel_name": "general",
+                "guild_id": "guild_id",
+                "guild_name": "TechFren",
+                "message_count": 1,
+            },
+            {
+                "channel_id": "links_id",
+                "channel_name": "links-dump",
+                "guild_id": "guild_id",
+                "guild_name": "TechFren",
+                "message_count": 1,
+            },
+            {
+                "channel_id": "dev_id",
+                "channel_name": "dev-chat",
+                "guild_id": "guild_id",
+                "guild_name": "TechFren",
+                "message_count": 1,
+            },
+        ]
+        messages_by_channel = {
+            "general_id": {
+                "messages": [self._message("g1", "Alice", "General update")]
+            },
+            "links_id": {
+                "messages": [self._message("l1", "Bob", "Useful link")]
+            },
+            "dev_id": {
+                "messages": [self._message("d1", "Casey", "Dev discussion")]
+            },
+        }
+
+        with (
+            patch.object(summarization_tasks.config, "summary_channel_ids", ["general_id", "links_id"]),
+            patch.object(summarization_tasks.config, "general_channel_id", "general_id"),
+            patch.object(summarization_tasks.database, "get_active_channels", return_value=active_channels),
+            patch.object(summarization_tasks.database, "get_messages_for_time_range", return_value=messages_by_channel),
+            patch.object(summarization_tasks.database, "get_user_engagement_metrics", return_value={}),
+            patch.object(summarization_tasks, "analyze_messages_for_points", new=AsyncMock(return_value=None)),
+            patch.object(summarization_tasks, "call_llm_for_summary", new=AsyncMock(return_value="summary")) as mock_summary,
+            patch.object(summarization_tasks.database, "store_channel_summary", return_value=True) as mock_store,
+            patch.object(summarization_tasks.database, "delete_messages_older_than", return_value=0),
+            patch.object(summarization_tasks, "post_summary_to_reports_channel", new=AsyncMock()),
+        ):
+            await summarization_tasks.run_daily_summarization_once(now=now)
+
+        general_calls = [
+            call for call in mock_summary.await_args_list
+            if call.args[1] == "all active channels"
+        ]
+        self.assertEqual(len(general_calls), 1)
+
+        summarized_messages = general_calls[0].args[0]
+        self.assertEqual(
+            {msg["channel_name"] for msg in summarized_messages},
+            {"general", "links-dump", "dev-chat"},
+        )
+
+        called_channel_scopes = [call.args[1] for call in mock_summary.await_args_list]
+        self.assertIn("links-dump", called_channel_scopes)
+        self.assertNotIn("dev-chat", called_channel_scopes)
+
+        general_store_call = next(
+            call for call in mock_store.call_args_list
+            if call.kwargs["channel_id"] == "general_id"
+        )
+        metadata = general_store_call.kwargs["metadata"]
+        self.assertEqual(metadata["summary_scope"], "all_active_channels")
+        self.assertEqual(
+            set(metadata["included_channel_names"]),
+            {"general", "links-dump", "dev-chat"},
+        )
+
+    def _message(self, message_id, author_name, content):
+        return {
+            "id": message_id,
+            "author_id": f"{author_name}_id",
+            "author_name": author_name,
+            "content": content,
+            "created_at": datetime(2026, 4, 13, 11, 0, tzinfo=timezone.utc),
+            "is_bot": False,
+            "is_command": False,
+            "scraped_url": None,
+            "scraped_content_summary": None,
+            "scraped_content_key_points": None,
+            "image_descriptions": None,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_daily_general_summary.py
+++ b/test_daily_general_summary.py
@@ -37,6 +37,20 @@ class TestDailyGeneralSummary(unittest.IsolatedAsyncioTestCase):
                 "guild_name": "TechFren",
                 "message_count": 1,
             },
+            {
+                "channel_id": "bot_id",
+                "channel_name": "bot-updates",
+                "guild_id": "guild_id",
+                "guild_name": "TechFren",
+                "message_count": 1,
+            },
+            {
+                "channel_id": "other_id",
+                "channel_name": "other-general",
+                "guild_id": "other_guild_id",
+                "guild_name": "Other Guild",
+                "message_count": 1,
+            },
         ]
         messages_by_channel = {
             "general_id": {
@@ -47,6 +61,12 @@ class TestDailyGeneralSummary(unittest.IsolatedAsyncioTestCase):
             },
             "dev_id": {
                 "messages": [self._message("d1", "Casey", "Dev discussion")]
+            },
+            "bot_id": {
+                "messages": [self._message("b1", "Summary Bot", "Yesterday's digest", is_bot=True)]
+            },
+            "other_id": {
+                "messages": [self._message("o1", "Devin", "Other guild discussion")]
             },
         }
 
@@ -90,16 +110,21 @@ class TestDailyGeneralSummary(unittest.IsolatedAsyncioTestCase):
             set(metadata["included_channel_names"]),
             {"general", "links-dump", "dev-chat"},
         )
+        self.assertEqual(
+            set(metadata["included_channel_ids"]),
+            {"general_id", "links_id", "dev_id"},
+        )
+        self.assertEqual(metadata["included_guild_id"], "guild_id")
 
-    def _message(self, message_id, author_name, content):
+    def _message(self, message_id, author_name, content, is_bot=False, is_command=False):
         return {
             "id": message_id,
             "author_id": f"{author_name}_id",
             "author_name": author_name,
             "content": content,
             "created_at": datetime(2026, 4, 13, 11, 0, tzinfo=timezone.utc),
-            "is_bot": False,
-            "is_command": False,
+            "is_bot": is_bot,
+            "is_command": is_command,
             "scraped_url": None,
             "scraped_content_summary": None,
             "scraped_content_key_points": None,


### PR DESCRIPTION
## Summary
- Make the daily summary posted in the configured general channel a server-wide digest across all active channels
- Keep `SUMMARY_CHANNEL_IDS` as a per-channel summary allowlist only
- Include channel names in cross-channel summary input so the LLM can distinguish message sources
- Update config/docs comments to clarify the behavior
- Add regression coverage for the general digest with restricted per-channel summaries

## Tests
- `.venv/bin/python -m pytest test_daily_general_summary.py -v`
- `.venv/bin/python -m py_compile summarization_tasks.py llm_handler.py config.py config.sample.py test_daily_general_summary.py`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author