### PR TITLE
Add admin /award-points command and manual award helper

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,12 @@ PERPLEXITY_API_KEY=YOUR_PERPLEXITY_API_KEY
 # You can change this to any model supported by Perplexity (sonar, sonar-reasoning, etc.)
 LLM_MODEL=sonar
 
+# Admin Configuration (optional)
+# Comma-separated Discord user IDs allowed to manually award points.
+# If unset, the bot falls back to allowing username/display name "techfren".
+ADMIN_USER_IDS=
+ADMIN_FALLBACK_USERNAME=techfren
+
 # Rate Limiting Configuration (optional)
 # Time between allowed requests per user (in seconds)
 RATE_LIMIT_SECONDS=10

--- a/bot.py
+++ b/bot.py
@@ -88,6 +88,25 @@ def message_contains_gif(message: discord.Message) -> bool:
     return False
 
 
+def _is_points_admin(user) -> bool:
+    """Return True when a Discord user may run admin-only point commands."""
+    user_id = str(user.id)
+    configured_admin_ids = getattr(config, 'ADMIN_USER_IDS', ())
+    if configured_admin_ids:
+        return user_id in configured_admin_ids
+
+    fallback_username = getattr(config, 'ADMIN_FALLBACK_USERNAME', 'techfren')
+    fallback_username = (fallback_username or '').strip().lower()
+    if not fallback_username:
+        return False
+
+    candidate_names = {
+        getattr(user, 'name', ''),
+        getattr(user, 'display_name', ''),
+        getattr(user, 'global_name', ''),
+    }
+    return any(name and name.lower() == fallback_username for name in candidate_names)
+
 def _member_has_free_weekly_color_change_role(member: discord.Member) -> bool:
     """
     Check whether a member has an eligible role for free weekly color changes.
@@ -1587,6 +1606,74 @@ async def points_slash(interaction: discord.Interaction, user: discord.User = No
         logger.error(f"Error in /points command: {str(e)}", exc_info=True)
         await interaction.response.send_message(
             "❌ An error occurred while retrieving points. Please try again later.",
+            ephemeral=True
+        )
+
+
+@bot.tree.command(name="award-points", description="Admin-only: manually award points to a user")
+async def award_points_slash(interaction: discord.Interaction, user: discord.User, points: int, reason: str = "Manual admin award"):
+    """Slash command for the configured admin to manually award points."""
+    try:
+        if not interaction.guild:
+            await interaction.response.send_message(
+                "❌ This command can only be used in a server.",
+                ephemeral=True
+            )
+            return
+
+        if not _is_points_admin(interaction.user):
+            await interaction.response.send_message(
+                "❌ Only the configured admin can manually award points.",
+                ephemeral=True
+            )
+            logger.warning(
+                f"Unauthorized /award-points attempt by {interaction.user} "
+                f"({interaction.user.id}) in guild {interaction.guild.id}"
+            )
+            return
+
+        if points <= 0:
+            await interaction.response.send_message(
+                "❌ Points must be a positive whole number.",
+                ephemeral=True
+            )
+            return
+
+        guild_id = str(interaction.guild.id)
+        target_user_id = str(user.id)
+        target_name = user.display_name
+
+        success = database.manually_award_points_to_user(
+            target_user_id,
+            target_name,
+            guild_id,
+            points
+        )
+        if not success:
+            await interaction.response.send_message(
+                "❌ Failed to award points. Please try again later.",
+                ephemeral=True
+            )
+            return
+
+        new_total = database.get_user_points(target_user_id, guild_id)
+        safe_reason = reason.strip() if reason and reason.strip() else "Manual admin award"
+        await interaction.response.send_message(
+            f"✅ Awarded {points} point(s) to **{target_name}**.\n"
+            f"🏆 New total: {new_total} point(s).\n"
+            f"📝 Reason: {safe_reason}",
+            ephemeral=True
+        )
+        logger.info(
+            f"Admin {interaction.user} ({interaction.user.id}) manually awarded "
+            f"{points} points to {target_name} ({target_user_id}) in guild {guild_id}. "
+            f"Reason: {safe_reason}"
+        )
+
+    except Exception as e:
+        logger.error(f"Error in /award-points command: {str(e)}", exc_info=True)
+        await interaction.response.send_message(
+            "❌ An error occurred while awarding points. Please try again later.",
             ephemeral=True
         )
 

--- a/config.py
+++ b/config.py
@@ -60,6 +60,17 @@ perplexity = os.getenv('PERPLEXITY_API_KEY')
 # Default model is "sonar" for Perplexity
 llm_model = os.getenv('LLM_MODEL', 'sonar')
 
+# Admin Configuration
+# Comma-separated Discord user IDs allowed to use admin-only point commands.
+# If unset, a Discord username/display name of "techfren" is allowed as a fallback.
+_admin_user_ids_raw = os.getenv('ADMIN_USER_IDS', '')
+ADMIN_USER_IDS = tuple(
+    user_id.strip()
+    for user_id in _admin_user_ids_raw.split(',')
+    if user_id.strip()
+)
+ADMIN_FALLBACK_USERNAME = os.getenv('ADMIN_FALLBACK_USERNAME', 'techfren').strip().lower()
+
 # Rate Limiting Configuration (optional)
 # Environment variables: RATE_LIMIT_SECONDS, MAX_REQUESTS_PER_MINUTE
 # Default values: 10 seconds cooldown, 6 requests per minute

--- a/database.py
+++ b/database.py
@@ -1092,6 +1092,58 @@ def award_points_to_user(
         logger.error(f"Error awarding points to user {author_id}: {str(e)}", exc_info=True)
         return False
 
+def manually_award_points_to_user(
+    author_id: str,
+    author_name: str,
+    guild_id: str,
+    points: int
+) -> bool:
+    """
+    Manually award any positive number of points to a user.
+
+    This is intended for trusted admin commands and intentionally does not use
+    the daily automated-award 20 point clamp in award_points_to_user().
+    """
+    try:
+        if not author_id or not author_id.strip():
+            logger.error("Cannot manually award points: author_id is empty or None")
+            return False
+
+        if points <= 0:
+            logger.warning(f"Skipping manual point award for {author_name}: points={points} (must be > 0)")
+            return False
+
+        now = datetime.now().isoformat()
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO user_points (author_id, author_name, guild_id, total_points, last_updated)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(author_id, guild_id) DO UPDATE SET
+                    total_points = total_points + ?,
+                    author_name = ?,
+                    last_updated = ?
+                """,
+                (
+                    author_id,
+                    author_name,
+                    guild_id,
+                    points,
+                    now,
+                    points,
+                    author_name,
+                    now
+                )
+            )
+            conn.commit()
+
+        logger.info(f"Manually awarded {points} points to user {author_name} ({author_id}) in guild {guild_id}")
+        return True
+    except Exception as e:
+        logger.error(f"Error manually awarding points to user {author_id}: {str(e)}", exc_info=True)
+        return False
+
 def get_user_points(author_id: str, guild_id: str) -> int:
     """
     Get the total points for a specific user in a guild.

--- a/test_gif_bypass.py
+++ b/test_gif_bypass.py
@@ -163,3 +163,29 @@ def test_database_deduct_insufficient_points(setup_database):
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 
+def test_database_manual_award_points_is_not_daily_clamped(setup_database):
+    """Test that manual admin awards can assign more than the automated daily clamp."""
+    import uuid
+
+    user_id = f"manual_user_{uuid.uuid4()}"
+    guild_id = f"guild_{uuid.uuid4()}"
+
+    success = database.manually_award_points_to_user(user_id, "ManualUser", guild_id, 75)
+    assert success is True
+    assert database.get_user_points(user_id, guild_id) == 75
+
+    success = database.manually_award_points_to_user(user_id, "ManualUser", guild_id, 30)
+    assert success is True
+    assert database.get_user_points(user_id, guild_id) == 105
+
+
+def test_database_manual_award_rejects_non_positive_points(setup_database):
+    """Test that manual admin awards reject zero and negative point values."""
+    import uuid
+
+    user_id = f"manual_user_{uuid.uuid4()}"
+    guild_id = f"guild_{uuid.uuid4()}"
+
+    assert database.manually_award_points_to_user(user_id, "ManualUser", guild_id, 0) is False
+    assert database.manually_award_points_to_user(user_id, "ManualUser", guild_id, -5) is False
+    assert database.get_user_points(user_id, guild_id) == 0


### PR DESCRIPTION
### Motivation
- Provide a way for a trusted admin to manually assign points to users outside the automated daily LLM-driven awards and their 20-point clamp.

### Description
- Add admin configuration via `ADMIN_USER_IDS` and `ADMIN_FALLBACK_USERNAME` (loaded from environment and documented in `.env.sample`) to control who may run admin point commands.
- Add `database.manually_award_points_to_user(...)` which atomically increments a user's `total_points` for arbitrary positive values and does not apply the automated 1–20 clamp.
- Add a helper `_is_points_admin(user)` and a new slash command `/award-points` that allows the configured admin to award points to a guild member with an optional reason and returns the new total.
- Add unit tests verifying manual awards can exceed the daily clamp and that non-positive manual awards are rejected (`test_gif_bypass.py` additions).

### Testing
- Ran the focused test file with required env vars: `DISCORD_BOT_TOKEN=x EXA_API_KEY=x XAI_API_KEY=x FIRECRAWL_API_KEY=x pytest -q test_gif_bypass.py`, which passed (`8 passed`).
- Verified module syntax by compiling the modified modules: `DISCORD_BOT_TOKEN=x EXA_API_KEY=x XAI_API_KEY=x FIRECRAWL_API_KEY=x python3 -m py_compile bot.py database.py config.py`, which succeeded.
- Attempted a full test run with all env keys set; the full suite contains pre-existing unrelated failures (async test collection and legacy mocks) that are not caused by this change and did not block the focused tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31bc38ab888330a4dddad328e4407b)